### PR TITLE
fix: 修复 Anima 模型下载脚本创建嵌套目录的问题

### DIFF
--- a/build-scripts/templates/Download-Anima-Model.bat
+++ b/build-scripts/templates/Download-Anima-Model.bat
@@ -3,35 +3,52 @@ chcp 65001 >nul 2>&1
 title Download Anima Model
 cd /d "%~dp0"
 
+set "SCRIPT_DIR=%~dp0"
+set "TRAINER_DIR="
+
+if exist "%SCRIPT_DIR%gui.py" (
+    set "TRAINER_DIR=%SCRIPT_DIR%"
+) else if exist "%SCRIPT_DIR%SD-Trainer\gui.py" (
+    set "TRAINER_DIR=%SCRIPT_DIR%SD-Trainer\"
+) else (
+    echo [Error] SD-Trainer directory not found.
+    echo.
+    echo Put this bat file in one of these locations:
+    echo   1. The portable package root, next to run_gui.bat
+    echo   2. The SD-Trainer folder, next to gui.py
+    echo.
+    pause
+    exit /b 1
+)
+
+set "MODEL_DIR=%TRAINER_DIR%sd-models\anima"
+set "BASE_URL=https://www.modelscope.cn/models/circlestone-labs/Anima/resolve/master/split_files"
+
 echo ============================================================
-echo   Anima Model Downloader / Anima 模型下载器
+echo   Anima Model Downloader
 echo ============================================================
 echo.
-echo   Files / 将下载以下文件:
+echo   Files:
 echo     1. anima-base-v1.0.safetensors   (DiT)
-echo     2. qwen_3_06b_base.safetensors   (Text Encoder / 文本编码器)
+echo     2. qwen_3_06b_base.safetensors   (Text Encoder)
 echo     3. qwen_image_vae.safetensors    (VAE)
 echo.
-echo   Save to / 保存到: SD-Trainer\sd-models\anima\
+echo   Save to:
+echo     %MODEL_DIR%
 echo.
-echo   Source / 来源: ModelScope (circlestone-labs/Anima)
+echo   Source: ModelScope (circlestone-labs/Anima)
 echo ============================================================
 echo.
-
-set "MODEL_DIR=%~dp0SD-Trainer\sd-models\anima"
-set "BASE_URL=https://www.modelscope.cn/models/circlestone-labs/Anima/resolve/master/split_files"
 
 if not exist "%MODEL_DIR%" mkdir "%MODEL_DIR%"
 
-:: ---- File 1: DiT ----
 if exist "%MODEL_DIR%\anima-base-v1.0.safetensors" (
-    echo [Skip] anima-base-v1.0.safetensors already exists / 已存在
+    echo [Skip] anima-base-v1.0.safetensors already exists
 ) else (
     echo [1/3] Downloading anima-base-v1.0.safetensors ...
-    echo       DiT model / DiT 主模型
     curl -L -# -o "%MODEL_DIR%\anima-base-v1.0.safetensors" "%BASE_URL%/diffusion_models/anima-base-v1.0.safetensors"
     if errorlevel 1 (
-        echo       [Failed] Download failed / 下载失败
+        echo       [Failed] Download failed
         del "%MODEL_DIR%\anima-base-v1.0.safetensors" 2>nul
     ) else (
         echo       [OK] Done
@@ -39,15 +56,13 @@ if exist "%MODEL_DIR%\anima-base-v1.0.safetensors" (
 )
 echo.
 
-:: ---- File 2: Text Encoder ----
 if exist "%MODEL_DIR%\qwen_3_06b_base.safetensors" (
-    echo [Skip] qwen_3_06b_base.safetensors already exists / 已存在
+    echo [Skip] qwen_3_06b_base.safetensors already exists
 ) else (
     echo [2/3] Downloading qwen_3_06b_base.safetensors ...
-    echo       Qwen3 Text Encoder / Qwen3 文本编码器
     curl -L -# -o "%MODEL_DIR%\qwen_3_06b_base.safetensors" "%BASE_URL%/text_encoders/qwen_3_06b_base.safetensors"
     if errorlevel 1 (
-        echo       [Failed] Download failed / 下载失败
+        echo       [Failed] Download failed
         del "%MODEL_DIR%\qwen_3_06b_base.safetensors" 2>nul
     ) else (
         echo       [OK] Done
@@ -55,15 +70,13 @@ if exist "%MODEL_DIR%\qwen_3_06b_base.safetensors" (
 )
 echo.
 
-:: ---- File 3: VAE ----
 if exist "%MODEL_DIR%\qwen_image_vae.safetensors" (
-    echo [Skip] qwen_image_vae.safetensors already exists / 已存在
+    echo [Skip] qwen_image_vae.safetensors already exists
 ) else (
     echo [3/3] Downloading qwen_image_vae.safetensors ...
-    echo       Qwen Image VAE
     curl -L -# -o "%MODEL_DIR%\qwen_image_vae.safetensors" "%BASE_URL%/vae/qwen_image_vae.safetensors"
     if errorlevel 1 (
-        echo       [Failed] Download failed / 下载失败
+        echo       [Failed] Download failed
         del "%MODEL_DIR%\qwen_image_vae.safetensors" 2>nul
     ) else (
         echo       [OK] Done
@@ -71,11 +84,10 @@ if exist "%MODEL_DIR%\qwen_image_vae.safetensors" (
 )
 echo.
 
-:: ---- Summary ----
 echo ============================================================
-echo   Download complete / 下载完成
+echo   Download complete
 echo.
-echo   Model path for WebUI / WebUI 中填写的模型路径:
+echo   Model paths for WebUI:
 echo     DiT:           ./sd-models/anima/anima-base-v1.0.safetensors
 echo     Text Encoder:  ./sd-models/anima/qwen_3_06b_base.safetensors
 echo     VAE:           ./sd-models/anima/qwen_image_vae.safetensors


### PR DESCRIPTION
Fixes #22
## 发现

反馈 `Download-Anima-Model.bat` 在下载 Anima 模型时，会在训练器目录内再次创建一层 `SD-Trainer`，形成类似 `SD-Trainer-v2.3.0\SD-Trainer\SD-Trainer` 的套娃目录。

排查后发现，脚本原先固定使用 `%~dp0SD-Trainer\sd-models\anima` 作为模型保存目录。当 bat 文件本身已经位于 `SD-Trainer` 目录内时，这个固定拼接会把路径变成 `SD-Trainer\SD-Trainer\sd-models\anima`。

## 改动

- 下载脚本启动时先判断自身所在位置。
- 如果当前目录存在 `gui.py`，则认为当前目录就是训练器目录。
- 如果当前目录存在 `SD-Trainer\gui.py`，则认为当前目录是整合包根目录。
- 找不到训练器目录时直接报错退出，避免静默创建错误目录。
- 保留下载的三个 Anima 模型文件和 WebUI 中填写的相对路径提示。

## 预期效果

无论用户从整合包根目录运行 `Download-Anima-Model.bat`，还是把它放在 `SD-Trainer` 目录内运行，模型都会下载到正确的 `sd-models\anima` 目录，不会再生成 `SD-Trainer\SD-Trainer` 嵌套目录。