### PR TITLE
fix(tagger): support visible local tagger model directory

### DIFF
--- a/build-scripts/03-copy-project.ps1
+++ b/build-scripts/03-copy-project.ps1
@@ -31,6 +31,7 @@ $excludeDirs = @(
     "logs",
     "output",
     "huggingface",
+    "tagger-models",
     "sd-models",
     "wd14_tagger_model",
     "train",
@@ -58,6 +59,9 @@ New-Item -ItemType Directory -Path (Join-Path $BuildDir "sd-models") -Force | Ou
 New-Item -ItemType Directory -Path (Join-Path $BuildDir "output") -Force | Out-Null
 New-Item -ItemType Directory -Path (Join-Path $BuildDir "logs") -Force | Out-Null
 New-Item -ItemType Directory -Path (Join-Path $BuildDir "huggingface") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $BuildDir "tagger-models") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $BuildDir "tagger-models\wd14") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $BuildDir "tagger-models\vlm") -Force | Out-Null
 
 Write-Host "用户目录创建完成" -ForegroundColor Green
 

--- a/build-scripts/build_portable.ps1
+++ b/build-scripts/build_portable.ps1
@@ -333,7 +333,11 @@ Write-Host ""
 Write-Host "[3/6] Bundling default WD tagger (wd14-convnextv2-v2, ~388 MB)..." -ForegroundColor Cyan
 
 $hfHome = Join-Path $portableDir "huggingface"
+$taggerModelsDir = Join-Path $portableDir "tagger-models"
 New-Item -ItemType Directory -Path $hfHome -Force | Out-Null
+New-Item -ItemType Directory -Path $taggerModelsDir -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $portableDir "tagger-models\wd14") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $portableDir "tagger-models\vlm") -Force | Out-Null
 $prefetchScript = Join-Path $sdtDir "scripts\prefetch_default_tagger.py"
 
 if (-not (Test-Path $prefetchScript)) {
@@ -342,13 +346,14 @@ if (-not (Test-Path $prefetchScript)) {
     Write-Host "  WARNING: no Python for tagger prefetch; tagger will download on first tag run" -ForegroundColor Yellow
 } else {
     $env:HF_HOME = $hfHome
+    $env:MIKAZUKI_TAGGER_MODELS_DIR = $taggerModelsDir
     # pip writes progress to stderr; with $ErrorActionPreference Stop that aborts the build.
     $prevEap = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
     $prefetchExit = 1
     if (Get-Command python -ErrorAction SilentlyContinue) {
         & python -m pip install -q huggingface_hub 2>&1 | Out-Null
-        & python $prefetchScript --hf-home $hfHome --if-missing
+        & python $prefetchScript --hf-home $hfHome --tagger-models-dir $taggerModelsDir --if-missing
         $prefetchExit = $LASTEXITCODE
     } elseif (Test-Path $pythonExe) {
         if (Test-Path $getPipPath) {
@@ -356,14 +361,14 @@ if (-not (Test-Path $prefetchScript)) {
             & $pythonExe $getPipPath --no-warn-script-location 2>&1 | Out-Null
         }
         & $pythonExe -s -m pip install -q huggingface_hub 2>&1 | Out-Null
-        & $pythonExe -s $prefetchScript --hf-home $hfHome --if-missing
+        & $pythonExe -s $prefetchScript --hf-home $hfHome --tagger-models-dir $taggerModelsDir --if-missing
         $prefetchExit = $LASTEXITCODE
     }
     $ErrorActionPreference = $prevEap
     if ($prefetchExit -ne 0) {
         Write-Host "  WARNING: tagger prefetch failed; 7z may ship without offline tagger" -ForegroundColor Yellow
     } else {
-        Write-Host "  Cached under huggingface/hub/" -ForegroundColor Green
+        Write-Host "  Cached under huggingface/hub/ and tagger-models/" -ForegroundColor Green
     }
 }
 
@@ -450,7 +455,7 @@ foreach ($bat in @("Update-SD-Trainer.bat", "Download-Anima-Model.bat")) {
 Write-Host ""
 Write-Host "[5/6] Creating user directories and README..." -ForegroundColor Cyan
 
-foreach ($d in @("sd-models", "output", "logs", "huggingface")) {
+foreach ($d in @("sd-models", "output", "logs", "huggingface", "tagger-models", "tagger-models\wd14", "tagger-models\vlm")) {
     $p = Join-Path $portableDir $d
     New-Item -ItemType Directory -Path $p -Force | Out-Null
     [System.IO.File]::WriteAllText((Join-Path $p ".gitkeep"), "")
@@ -463,8 +468,10 @@ $readme += "  1. Double-click run_gui.bat`r`n"
 $readme += "  2. First launch requires internet (downloads ~3 GB of PyTorch)`r`n"
 $readme += "  3. Open http://127.0.0.1:28000 in browser`r`n`r`n"
 $readme += "Tagging:`r`n"
-$readme += "  Default WD tagger (wd14-convnextv2-v2) is bundled under huggingface/`r`n"
-$readme += "  (~400 MB). Use the built-in Tagger page without extra model download.`r`n`r`n"
+$readme += "  Default WD tagger (wd14-convnextv2-v2) is bundled under tagger-models/wd14/`r`n"
+$readme += "  (~400 MB). Put extra WD/CL tag models in tagger-models/wd14/<model-key>/`r`n"
+$readme += "  Future VLM caption models can be placed under tagger-models/vlm/<model-key>/`r`n"
+$readme += "  with the files required by that model, such as model.onnx and selected_tags.csv.`r`n`r`n"
 $readme += "Directories:`r`n"
 $readme += "  run_gui.bat      - Stable entrypoint for portable users`r`n"
 $readme += "  run_gui_portable.bat - Legacy shim (logic in SD-Trainer/scripts/portable/)`r`n"
@@ -473,6 +480,7 @@ $readme += "  SD-Trainer/      - Project files`r`n"
 $readme += "  sd-models/       - Put your models here`r`n"
 $readme += "  output/          - Training output`r`n"
 $readme += "  logs/            - Logs`r`n`r`n"
+$readme += "  tagger-models/   - Local tagger models`r`n`r`n"
 $readme += "Update:`r`n"
 $readme += "  update\update_sd_trainer.bat       - Shortcut to Update-SD-Trainer.bat`r`n"
 $readme += "  update\update_dependencies.bat     - Update Python packages`r`n`r`n"

--- a/docs/api/dataset-tagging.md
+++ b/docs/api/dataset-tagging.md
@@ -62,6 +62,23 @@
 - `https://hf-mirror.com`
 - `https://modelscope.cn`
 
+## 本地打标模型目录
+
+WebUI 会优先检查本地 `tagger-models/<family>/<model-key>/`，文件齐全时不会访问 Hugging Face。默认模型目录为：
+
+```text
+tagger-models/wd14/wd14-convnextv2-v2/
+  model.onnx
+  selected_tags.csv
+```
+
+整合包会把默认 WD 模型放入该目录。用户也可以手动下载其它模型并放到对应的分类子目录：
+
+- `tagger-models/wd14/<model-key>/`：WD14 / CL 系列，主要用于 tag 打标。
+- `tagger-models/vlm/<model-key>/`：预留给 VLM / 自然语言描述模型。
+
+为兼容已安装用户，旧的一层目录 `tagger-models/<model-key>/` 仍可识别。如果文件不完整，系统会继续回退到原有 `huggingface/` 缓存或在线下载流程。
+
 **成功**：`status: success`，`message: 模型下载已开始`  
 **失败**：已有任务进行中、未知模型等返回 `status: fail`。
 

--- a/docs/portable-packaging-git-update.md
+++ b/docs/portable-packaging-git-update.md
@@ -28,6 +28,9 @@
   output/
   logs/
   huggingface/
+  tagger-models/
+  tagger-models/wd14/
+  tagger-models/vlm/
 ```
 
 这些路径被用户快捷方式、启动脚本和文档绑定，不要随意改名。
@@ -69,6 +72,9 @@ sd-models/
 output/
 logs/
 huggingface/
+tagger-models/
+tagger-models/wd14/
+tagger-models/vlm/
 train/
 config/
 toml/autosave/

--- a/install-cn.ps1
+++ b/install-cn.ps1
@@ -1,4 +1,5 @@
 ﻿$Env:HF_HOME = "huggingface"
+$Env:MIKAZUKI_TAGGER_MODELS_DIR = "tagger-models"
 $Env:PIP_DISABLE_PIP_VERSION_CHECK = 1
 $Env:PIP_NO_CACHE_DIR = 1
 $Env:PIP_INDEX_URL = "https://pypi.tuna.tsinghua.edu.cn/simple"
@@ -177,7 +178,7 @@ python -m pip install --upgrade -r requirements.txt
 Check "训练依赖库安装失败。"
 
 Write-Output "预下载默认 WD 打标模型 wd14-convnextv2-v2（约 388MB，首次较慢）..."
-python scripts/prefetch_default_tagger.py --if-missing
+python scripts/prefetch_default_tagger.py --if-missing --tagger-models-dir "$Env:MIKAZUKI_TAGGER_MODELS_DIR"
 if ($LASTEXITCODE -ne 0) {
     Write-Output "警告: 默认打标模型预下载失败，可在启动后于「打标」页首次使用时自动下载。"
 }

--- a/mikazuki/tagger/interrogators/cl.py
+++ b/mikazuki/tagger/interrogators/cl.py
@@ -14,6 +14,7 @@ from huggingface_hub import hf_hub_download
 from dataclasses import dataclass
 from mikazuki.tagger import dbimutils, format
 from mikazuki.tagger.interrogators.base import Interrogator
+from mikazuki.tagger.local_models import local_model_asset_paths
 
 
 @dataclass
@@ -139,6 +140,11 @@ class CLTaggerInterrogator(Interrogator):
         self.kwargs = kwargs
 
     def download(self) -> Tuple[os.PathLike, os.PathLike]:
+        local_paths = local_model_asset_paths(self.name, self)
+        if local_paths:
+            print(f"Loading {self.name} model from local tagger-models directory")
+            return local_paths
+
         print(f"Loading {self.name} model file from {self.kwargs['repo_id']}")
 
         model_path = Path(hf_hub_download(

--- a/mikazuki/tagger/interrogators/wd14.py
+++ b/mikazuki/tagger/interrogators/wd14.py
@@ -14,6 +14,7 @@ from PIL import UnidentifiedImageError
 from huggingface_hub import hf_hub_download
 from mikazuki.tagger.interrogators.base import Interrogator
 from mikazuki.tagger import dbimutils, format
+from mikazuki.tagger.local_models import local_model_asset_paths
 
 
 class WaifuDiffusionInterrogator(Interrogator):
@@ -30,6 +31,11 @@ class WaifuDiffusionInterrogator(Interrogator):
         self.kwargs = kwargs
 
     def download(self) -> Tuple[os.PathLike, os.PathLike]:
+        local_paths = local_model_asset_paths(self.name, self)
+        if local_paths:
+            print(f"Loading {self.name} model from local tagger-models directory")
+            return local_paths
+
         repo_id = self.kwargs["repo_id"]
         print(f"Loading {self.name} model from {repo_id} (first run may download ~400MB, see console log)")
 

--- a/mikazuki/tagger/jobs.py
+++ b/mikazuki/tagger/jobs.py
@@ -24,7 +24,7 @@ def run_prefetch_job(req) -> None:
 
     try:
         with use_download_endpoint(getattr(req, "download_endpoint", "")):
-            if interrogator_assets_ready(interrogator):
+            if interrogator_assets_ready(interrogator, model_key):
                 tagger_progress.finish_download_success(f"模型 {model_key} 已在本地")
                 return
             download_interrogator_assets(model_key, interrogator, continue_to_tagging=False)
@@ -43,7 +43,7 @@ def run_interrogate_job(req) -> None:
         model_key, available_interrogators["wd14-convnextv2-v2"]
     )
 
-    needs_download = not interrogator_assets_ready(interrogator)
+    needs_download = not interrogator_assets_ready(interrogator, model_key)
     initial_phase = "downloading" if needs_download else "tagging"
     initial_message = (
         "正在下载模型，完成后自动开始打标…"

--- a/mikazuki/tagger/local_models.py
+++ b/mikazuki/tagger/local_models.py
@@ -1,0 +1,61 @@
+"""Project-owned local storage for tagger model assets."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mikazuki.tagger.interrogators.base import Interrogator
+
+
+TAGGER_MODELS_DIR_ENV = "MIKAZUKI_TAGGER_MODELS_DIR"
+DEFAULT_TAGGER_MODELS_DIR = "tagger-models"
+WD14_MODEL_FAMILY = "wd14"
+VLM_MODEL_FAMILY = "vlm"
+
+
+def local_models_root() -> Path:
+    configured = os.environ.get(TAGGER_MODELS_DIR_ENV)
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return (Path.cwd() / DEFAULT_TAGGER_MODELS_DIR).resolve()
+
+
+def local_model_dir(model_key: str) -> Path:
+    return local_models_root() / local_model_family(model_key) / model_key
+
+
+def legacy_local_model_dir(model_key: str) -> Path:
+    return local_models_root() / model_key
+
+
+def local_model_family(model_key: str) -> str:
+    if model_key.startswith("wd") or model_key.startswith("cl_tagger"):
+        return WD14_MODEL_FAMILY
+    return VLM_MODEL_FAMILY
+
+
+def asset_filenames(interrogator: "Interrogator") -> list[str]:
+    files: list[str] = []
+    for attr in ("model_path", "tags_path", "tag_mapping_path"):
+        value = getattr(interrogator, attr, None)
+        if value:
+            files.append(str(value).replace("\\", "/"))
+    return files
+
+
+def local_model_asset_paths(
+    model_key: str,
+    interrogator: "Interrogator",
+) -> tuple[Path, ...] | None:
+    files = asset_filenames(interrogator)
+    if not files:
+        return None
+
+    for model_dir in (local_model_dir(model_key), legacy_local_model_dir(model_key)):
+        paths = tuple(model_dir / filename for filename in files)
+        if all(path.is_file() for path in paths):
+            return paths
+    return None

--- a/mikazuki/tagger/model_fetch.py
+++ b/mikazuki/tagger/model_fetch.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Iterator
 
 from huggingface_hub import hf_hub_download, try_to_load_from_cache
 
+from mikazuki.tagger.local_models import asset_filenames, local_model_asset_paths
 from mikazuki.tagger.progress import TaggerCancelled, tagger_progress
 
 if TYPE_CHECKING:
@@ -16,17 +17,7 @@ if TYPE_CHECKING:
 
 
 def _asset_filenames(interrogator: "Interrogator") -> list[str]:
-    model_path = getattr(interrogator, "model_path", None)
-    tags_path = getattr(interrogator, "tags_path", None)
-    mapping_path = getattr(interrogator, "tag_mapping_path", None)
-    files: list[str] = []
-    if model_path:
-        files.append(str(model_path))
-    if tags_path:
-        files.append(str(tags_path))
-    if mapping_path:
-        files.append(str(mapping_path))
-    return files
+    return asset_filenames(interrogator)
 
 
 def _hf_kwargs(interrogator: "Interrogator") -> dict:
@@ -53,8 +44,10 @@ def _file_cached(kwargs: dict, filename: str) -> bool:
         return False
 
 
-def interrogator_assets_ready(interrogator: "Interrogator") -> bool:
+def interrogator_assets_ready(interrogator: "Interrogator", model_key: str | None = None) -> bool:
     """Return True when all HF files for this interrogator are already in the local cache."""
+    if model_key and local_model_asset_paths(model_key, interrogator):
+        return True
     kwargs = _hf_kwargs(interrogator)
     files = _asset_filenames(interrogator)
     if not files:
@@ -166,7 +159,7 @@ def ensure_interrogator_assets(model_key: str, interrogator: "Interrogator") -> 
 
     Returns True if a download was performed (caller should expect brief load after).
     """
-    if interrogator_assets_ready(interrogator):
+    if interrogator_assets_ready(interrogator, model_key):
         return False
     download_interrogator_assets(model_key, interrogator, continue_to_tagging=True)
     return True

--- a/scripts/portable/README.md
+++ b/scripts/portable/README.md
@@ -36,4 +36,16 @@
 | Python | `python_embeded` | 系统 / `venv` |
 | 入口 | `run_gui.bat` → `launch_portable.bat` | `run_gui.bat` → `run_gui_source.bat` |
 | 首次依赖 | `setup_environment.py` | `install-cn.ps1` |
-| 默认打标模型 | 7z 内置 `huggingface/hub/`（wd14-convnextv2-v2） | `install-cn.ps1` + 每次启动 `prefetch_default_tagger.py --if-missing` |
+| 默认打标模型 | 7z 内置 `tagger-models/wd14/wd14-convnextv2-v2/`，并保留 `huggingface/` 缓存兜底 | `install-cn.ps1` + 每次启动 `prefetch_default_tagger.py --if-missing` |
+
+## 打标模型目录
+
+整合包根目录包含 `tagger-models/`，用于放置用户可见的本地打标模型。默认 WD 模型位置：
+
+```text
+<PortableRoot>/tagger-models/wd14/wd14-convnextv2-v2/
+  model.onnx
+  selected_tags.csv
+```
+
+WD14 / CL 系列放在 `tagger-models/wd14/<model-key>/`，主要用于 tag 打标。VLM / 自然语言描述模型预留 `tagger-models/vlm/<model-key>/`。旧的一层目录 `tagger-models/<model-key>/` 仍兼容；文件缺失时会继续使用 `huggingface/` 缓存或在线下载。

--- a/scripts/portable/launch_portable.bat
+++ b/scripts/portable/launch_portable.bat
@@ -11,6 +11,7 @@ title SD-Trainer
 set "PORTABLE_ROOT=%~dp0..\..\..\"
 set "BASE_DIR=%PORTABLE_ROOT%"
 set "HF_HOME=%PORTABLE_ROOT%huggingface"
+set "MIKAZUKI_TAGGER_MODELS_DIR=%PORTABLE_ROOT%tagger-models"
 if not defined HF_ENDPOINT set "HF_ENDPOINT=https://hf-mirror.com"
 set "PYTHONUTF8=1"
 set "PYTHON_EXE=%PORTABLE_ROOT%python_embeded\python.exe"
@@ -61,7 +62,7 @@ if errorlevel 1 goto :no_project
 
 if exist "scripts\prefetch_default_tagger.py" (
     echo [tagger] Ensuring default WD tagger cache >> "%LOG_FILE%"
-    "%PYTHON_EXE%" -s scripts\prefetch_default_tagger.py --if-missing >> "%LOG_FILE%" 2>&1
+    "%PYTHON_EXE%" -s scripts\prefetch_default_tagger.py --if-missing --tagger-models-dir "%MIKAZUKI_TAGGER_MODELS_DIR%" >> "%LOG_FILE%" 2>&1
 )
 
 echo [launch] Starting gui.py >> "%LOG_FILE%"

--- a/scripts/prefetch_default_tagger.py
+++ b/scripts/prefetch_default_tagger.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Download the default WD tagger into HF_HOME cache (source install + portable build)."""
+"""Download the default WD tagger into HF cache and the visible tagger-models folder."""
 
 from __future__ import annotations
 
@@ -18,6 +18,10 @@ from mikazuki.tagger.defaults import (  # noqa: E402
     DEFAULT_TAGGER_REPO_ID,
     DEFAULT_TAGGER_REVISION,
 )
+from mikazuki.tagger.local_models import (  # noqa: E402
+    DEFAULT_TAGGER_MODELS_DIR,
+    local_model_family,
+)
 
 
 def _resolve_hf_home(explicit: str | None) -> Path:
@@ -27,6 +31,23 @@ def _resolve_hf_home(explicit: str | None) -> Path:
     if env:
         return Path(env).resolve()
     return (REPO_ROOT / "huggingface").resolve()
+
+
+def _resolve_tagger_models_dir(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    return (REPO_ROOT / DEFAULT_TAGGER_MODELS_DIR).resolve()
+
+
+def _default_local_model_dir(tagger_models_dir: Path) -> Path:
+    return tagger_models_dir / local_model_family(DEFAULT_TAGGER_KEY) / DEFAULT_TAGGER_KEY
+
+
+def is_default_tagger_in_local_dir(tagger_models_dir: Path | None = None) -> bool:
+    model_dir = _default_local_model_dir(
+        _resolve_tagger_models_dir(str(tagger_models_dir) if tagger_models_dir else None)
+    )
+    return all((model_dir / filename).is_file() for filename in DEFAULT_TAGGER_FILES)
 
 
 def is_default_tagger_cached(hf_home: Path | None = None) -> bool:
@@ -53,20 +74,28 @@ def is_default_tagger_cached(hf_home: Path | None = None) -> bool:
 def ensure_default_tagger_model(
     hf_home: Path | None = None,
     *,
+    tagger_models_dir: Path | None = None,
     use_china_mirror: bool = True,
     force: bool = False,
 ) -> Path:
     hf_home = _resolve_hf_home(str(hf_home) if hf_home else None)
+    tagger_models_dir = _resolve_tagger_models_dir(
+        str(tagger_models_dir) if tagger_models_dir else None
+    )
     hf_home.mkdir(parents=True, exist_ok=True)
+    model_dir = _default_local_model_dir(tagger_models_dir)
+    model_dir.mkdir(parents=True, exist_ok=True)
     os.environ["HF_HOME"] = str(hf_home)
+    os.environ["MIKAZUKI_TAGGER_MODELS_DIR"] = str(tagger_models_dir)
 
     if use_china_mirror and not os.environ.get("HF_ENDPOINT"):
         os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
 
-    if not force and is_default_tagger_cached(hf_home):
+    local_ready = is_default_tagger_in_local_dir(tagger_models_dir)
+    if not force and local_ready:
         print(f"[tagger] Default model already present ({DEFAULT_TAGGER_KEY})")
-        print(f"         cache: {hf_home / 'hub'}")
-        return hf_home
+        print(f"         local: {model_dir}")
+        return model_dir
 
     try:
         from huggingface_hub import hf_hub_download
@@ -78,6 +107,7 @@ def ensure_default_tagger_model(
     print(f"[tagger] Downloading default WD tagger: {DEFAULT_TAGGER_REPO_ID}")
     print(f"         revision={DEFAULT_TAGGER_REVISION} (~388 MB, please wait)")
     print(f"         HF_HOME={hf_home}")
+    print(f"         local={model_dir}")
     if os.environ.get("HF_ENDPOINT"):
         print(f"         HF_ENDPOINT={os.environ['HF_ENDPOINT']}")
 
@@ -89,9 +119,14 @@ def ensure_default_tagger_model(
             revision=DEFAULT_TAGGER_REVISION,
         )
         print(f"[tagger]     -> {path}")
+        target = model_dir / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if force or not target.is_file():
+            target.write_bytes(Path(path).read_bytes())
+            print(f"[tagger]     local copy -> {target}")
 
     print(f"[tagger] Done. WebUI tagging can use '{DEFAULT_TAGGER_KEY}' offline.")
-    return hf_home
+    return model_dir
 
 
 def main() -> int:
@@ -99,6 +134,10 @@ def main() -> int:
     parser.add_argument(
         "--hf-home",
         help="HF cache root (default: ./huggingface or HF_HOME env)",
+    )
+    parser.add_argument(
+        "--tagger-models-dir",
+        help=f"Visible tagger model root (default: ./{DEFAULT_TAGGER_MODELS_DIR})",
     )
     parser.add_argument(
         "--if-missing",
@@ -118,12 +157,14 @@ def main() -> int:
     args = parser.parse_args()
 
     hf_home = _resolve_hf_home(args.hf_home)
+    tagger_models_dir = _resolve_tagger_models_dir(args.tagger_models_dir)
 
-    if args.if_missing and is_default_tagger_cached(hf_home) and not args.force:
+    if args.if_missing and is_default_tagger_in_local_dir(tagger_models_dir) and not args.force:
         return 0
 
     ensure_default_tagger_model(
         hf_home,
+        tagger_models_dir=tagger_models_dir,
         use_china_mirror=not args.no_mirror,
         force=args.force,
     )

--- a/tests/test_portable_packaging_scripts.py
+++ b/tests/test_portable_packaging_scripts.py
@@ -40,3 +40,18 @@ def test_portable_launcher_keeps_default_hf_mirror_for_skip_prepare_mode():
 
     assert "HF_ENDPOINT" in launcher
     assert "https://hf-mirror.com" in launcher
+
+
+def test_portable_builder_bundles_visible_tagger_models_directory():
+    script = (ROOT / "build-scripts" / "build_portable.ps1").read_text(
+        encoding="utf-8"
+    )
+    launcher = (ROOT / "scripts" / "portable" / "launch_portable.bat").read_text(
+        encoding="utf-8"
+    )
+
+    assert "tagger-models" in script
+    assert "tagger-models\\wd14" in script
+    assert "tagger-models\\vlm" in script
+    assert "--tagger-models-dir" in script
+    assert "MIKAZUKI_TAGGER_MODELS_DIR" in launcher

--- a/tests/test_tagger_progress_api.py
+++ b/tests/test_tagger_progress_api.py
@@ -5,6 +5,11 @@ from fastapi.testclient import TestClient
 from mikazuki.app.application import app
 from mikazuki.tagger.model_fetch import use_download_endpoint
 from mikazuki.tagger.progress import tagger_progress
+from mikazuki.tagger.interrogators.wd14 import WaifuDiffusionInterrogator
+from mikazuki.tagger.local_models import (
+    local_model_asset_paths,
+    local_model_dir,
+)
 
 
 def test_tagger_status_idle():
@@ -43,3 +48,53 @@ def test_tagger_default_download_endpoint_preserves_existing_hf_endpoint(monkeyp
         assert os.environ["HF_ENDPOINT"] == "https://hf-mirror.com"
 
     assert os.environ["HF_ENDPOINT"] == "https://hf-mirror.com"
+
+
+def test_tagger_local_model_directory_resolves_by_model_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
+
+    expected = tmp_path / "tagger-models" / "wd14" / "wd14-convnextv2-v2"
+
+    assert local_model_dir("wd14-convnextv2-v2") == expected
+
+
+def test_tagger_assets_ready_when_files_exist_in_wd14_local_model_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
+    model_dir = tmp_path / "tagger-models" / "wd14" / "wd14-convnextv2-v2"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.onnx").write_bytes(b"fake onnx")
+    (model_dir / "selected_tags.csv").write_text("name,category\n", encoding="utf-8")
+
+    interrogator = WaifuDiffusionInterrogator(
+        "wd14-convnextv2-v2",
+        repo_id="SmilingWolf/wd-v1-4-convnextv2-tagger-v2",
+        revision="v2.0",
+    )
+
+    assert local_model_asset_paths("wd14-convnextv2-v2", interrogator) == (
+        model_dir / "model.onnx",
+        model_dir / "selected_tags.csv",
+    )
+    assert interrogator.download() == (
+        model_dir / "model.onnx",
+        model_dir / "selected_tags.csv",
+    )
+
+
+def test_tagger_assets_keep_legacy_flat_local_model_dir_compatible(tmp_path, monkeypatch):
+    monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
+    model_dir = tmp_path / "tagger-models" / "wd14-convnextv2-v2"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.onnx").write_bytes(b"fake onnx")
+    (model_dir / "selected_tags.csv").write_text("name,category\n", encoding="utf-8")
+
+    interrogator = WaifuDiffusionInterrogator(
+        "wd14-convnextv2-v2",
+        repo_id="SmilingWolf/wd-v1-4-convnextv2-tagger-v2",
+        revision="v2.0",
+    )
+
+    assert local_model_asset_paths("wd14-convnextv2-v2", interrogator) == (
+        model_dir / "model.onnx",
+        model_dir / "selected_tags.csv",
+    )


### PR DESCRIPTION
## Summary

- Add a project-owned `tagger-models/` lookup path for WD14/CL tagger assets.
- Let old tagger downloads and prefetch reuse visible local files before falling back to Hugging Face cache/download.
- Create/copy portable `tagger-models/wd14` and `tagger-models/vlm` directories and document manual placement.

## Why

Many users report WD tagger model downloads failing. This gives them a clear project-local folder where they can manually place `model.onnx` and `selected_tags.csv` for WD14 models, while keeping the existing HF cache/download fallback.

## Tests

```powershell
python -m pytest tests\test_tagger_progress_api.py tests\test_portable_packaging_scripts.py -q
python -m pytest tests\test_dataset_editor_api.py tests\test_tagger_progress_api.py tests\test_portable_packaging_scripts.py -q
```