### PR TITLE
fix: repair dataset tag editor controls

### DIFF
--- a/frontend/dist/assets/dataset-editor-entry.js
+++ b/frontend/dist/assets/dataset-editor-entry.js
@@ -70,8 +70,10 @@
 
             <div id="side-panel-tagger" class="de-tab-panel">
               <h2>批量打标</h2>
-              <p class="de-placeholder">预留位置：后续接入现有数据集打标能力，只作用于当前范围。</p>
-              <button type="button" disabled>开始打标</button>
+              <p class="de-placeholder">为当前范围追加触发词；可先打标，再把角色名、画风词等触发词补到 caption 末尾。</p>
+              <label for="tagger-trigger-tags">额外触发词</label>
+              <input id="tagger-trigger-tags" type="text" placeholder="character name, style trigger">
+              <button id="apply-tagger-trigger" type="button">追加到当前范围</button>
             </div>
 
             <div id="side-panel-quick" class="de-tab-panel">

--- a/frontend/dist/assets/dataset-editor.css
+++ b/frontend/dist/assets/dataset-editor.css
@@ -5,6 +5,10 @@
   --de-border: #d8dde6;
   --de-text: #1f2937;
   --de-muted: #667085;
+  --de-input-bg: #ffffff;
+  --de-control-bg: #ffffff;
+  --de-control-text: var(--de-text);
+  --de-card-bg: #ffffff;
   --de-accent: #0f766e;
   --de-accent-strong: #0b5f59;
   --de-warn: #b45309;
@@ -35,8 +39,8 @@ button {
   min-height: 34px;
   border: 1px solid var(--de-border);
   border-radius: 6px;
-  background: #fff;
-  color: var(--de-text);
+  background: var(--de-control-bg);
+  color: var(--de-control-text);
   cursor: pointer;
 }
 
@@ -55,7 +59,7 @@ textarea {
   width: 100%;
   border: 1px solid var(--de-border);
   border-radius: 6px;
-  background: #fff;
+  background: var(--de-input-bg);
   color: var(--de-text);
   outline: none;
 }
@@ -246,7 +250,7 @@ label {
 }
 
 .de-tab.is-active {
-  background: #fff;
+  background: var(--de-card-bg);
   color: var(--de-accent-strong);
   box-shadow: 0 1px 2px rgba(16, 24, 40, 0.08);
 }
@@ -592,8 +596,12 @@ label {
   --de-bg: var(--c-bg-soft, #f9f9f9);
   --de-surface: var(--c-bg, #ffffff);
   --de-border: var(--c-border, rgba(60, 60, 60, 0.12));
-  --de-text: var(--c-text-1, #213547);
-  --de-muted: var(--c-text-2, rgba(60, 60, 60, 0.7));
+  --de-text: #213547;
+  --de-muted: #5f6b7a;
+  --de-input-bg: #ffffff;
+  --de-control-bg: #ffffff;
+  --de-control-text: #213547;
+  --de-card-bg: #ffffff;
   --de-accent: var(--c-brand, #646cff);
   --de-accent-strong: var(--c-brand-dark, #535bf2);
   --de-workbench-min-width: 960px;
@@ -602,6 +610,7 @@ label {
   grid-template-rows: 1fr;
   padding: 8px 12px 14px;
   background: var(--de-bg);
+  color: var(--de-text);
 }
 
 .de-shell-embedded .de-workspace {
@@ -641,6 +650,8 @@ label {
 .de-shell-embedded textarea {
   border-color: var(--de-border);
   border-radius: 6px;
+  background: var(--de-input-bg);
+  color: var(--de-text);
 }
 
 .de-shell-embedded .de-dataset-path,
@@ -651,6 +662,21 @@ label {
 
 .de-shell-embedded button {
   border-radius: 6px;
+  background: var(--de-control-bg);
+  color: var(--de-control-text);
+}
+
+.de-shell-embedded .de-primary {
+  border-color: var(--de-accent);
+  background: var(--de-accent);
+  color: #fff;
+}
+
+.de-shell-embedded .de-card,
+.de-shell-embedded .de-preview,
+.de-shell-embedded .de-gallery-empty {
+  background: var(--de-card-bg);
+  color: var(--de-text);
 }
 
 .de-shell-embedded .de-tabs {

--- a/frontend/dist/assets/dataset-editor.js
+++ b/frontend/dist/assets/dataset-editor.js
@@ -88,6 +88,8 @@
     replaceTo: document.getElementById("replace-to"),
     sort: document.getElementById("sort-tags"),
     batch: document.getElementById("apply-batch"),
+    taggerTrigger: document.getElementById("tagger-trigger-tags"),
+    taggerTriggerApply: document.getElementById("apply-tagger-trigger"),
     cleanCaption: document.getElementById("clean-caption"),
     cleanUnderscore: document.getElementById("clean-underscore"),
     cleanEscape: document.getElementById("clean-escape"),
@@ -417,6 +419,7 @@
     el.prev.disabled = state.selected <= 0;
     el.next.disabled = state.selected < 0 || state.selected >= state.filtered.length - 1;
     el.batch.disabled = state.filtered.length === 0;
+    el.taggerTriggerApply.disabled = state.filtered.length === 0 || !el.taggerTrigger.value.trim();
 
     if (!item) {
       el.preview.innerHTML = "<span>未选择图片</span>";
@@ -723,6 +726,33 @@
     }
   }
 
+  async function applyTaggerTrigger() {
+    const targets = selectedBatchItems();
+    const triggerTags = splitTags(el.taggerTrigger.value);
+    if (!targets.length || !triggerTags.length) return;
+    const scope = state.selectedPaths.size ? "已选中" : "当前筛选结果中";
+    const ok = window.confirm(`将额外触发词追加到${scope}的 ${targets.length} 张图片，是否继续？`);
+    if (!ok) return;
+    try {
+      const data = await api("/api/dataset-editor/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          root: state.root,
+          images: targets.map((item) => item.relative_path),
+          append: splitTags(el.taggerTrigger.value),
+        }),
+      });
+      applyChangedItems(data.items || []);
+      state.dirty = false;
+      setStatus(`额外触发词已追加，修改 ${data.changed || 0} 张图片。`);
+      await refreshHistory();
+      applyFilters();
+    } catch (err) {
+      setStatus(err.message, true);
+    }
+  }
+
   function appendTagToCaption(tag) {
     const item = currentItem();
     if (!item) return;
@@ -798,6 +828,14 @@
   el.prev.addEventListener("click", () => selectIndex(state.selected - 1));
   el.next.addEventListener("click", () => selectIndex(state.selected + 1));
   el.batch.addEventListener("click", applyBatch);
+  el.taggerTrigger.addEventListener("input", renderEditor);
+  el.taggerTrigger.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      applyTaggerTrigger();
+    }
+  });
+  el.taggerTriggerApply.addEventListener("click", applyTaggerTrigger);
   el.cleanup.addEventListener("click", applyCleanup);
   el.quickTagAdd.addEventListener("click", addQuickTag);
   el.quickTagInput.addEventListener("keydown", (event) => {

--- a/frontend/dist/dataset-editor.html
+++ b/frontend/dist/dataset-editor.html
@@ -99,8 +99,10 @@
 
           <div id="side-panel-tagger" class="de-tab-panel">
             <h2>批量打标</h2>
-            <p class="de-placeholder">预留位置：后续接入现有数据集打标能力，只作用于当前范围。</p>
-            <button type="button" disabled>开始打标</button>
+            <p class="de-placeholder">为当前范围追加触发词；可先打标，再把角色名、画风词等触发词补到 caption 末尾。</p>
+            <label for="tagger-trigger-tags">额外触发词</label>
+            <input id="tagger-trigger-tags" type="text" placeholder="character name, style trigger">
+            <button id="apply-tagger-trigger" type="button">追加到当前范围</button>
           </div>
 
           <div id="side-panel-quick" class="de-tab-panel">

--- a/tests/test_dataset_editor_api.py
+++ b/tests/test_dataset_editor_api.py
@@ -489,3 +489,44 @@ def test_dataset_editor_left_sidebar_owns_dataset_scope_and_tagger():
     assert "tagger: document.getElementById" in script
     assert ".de-scope-card" in css
     assert "grid-template-columns: repeat(5, 1fr)" in css
+
+
+def test_dataset_editor_tagger_panel_can_append_trigger_words():
+    html = (ROOT / "frontend" / "dist" / "dataset-editor.html").read_text(encoding="utf-8")
+    entry = (ROOT / "frontend" / "dist" / "assets" / "dataset-editor-entry.js").read_text(
+        encoding="utf-8"
+    )
+    script = (ROOT / "frontend" / "dist" / "assets" / "dataset-editor.js").read_text(
+        encoding="utf-8"
+    )
+
+    for markup in (html, entry):
+        assert 'id="tagger-trigger-tags"' in markup
+        assert 'id="apply-tagger-trigger"' in markup
+        assert "额外触发词" in markup
+        assert "预留位置" not in markup
+
+    assert "taggerTrigger" in script
+    assert "applyTaggerTrigger" in script
+    assert "额外触发词" in script
+    assert 'append: splitTags(el.taggerTrigger.value)' in script
+
+
+def test_dataset_editor_embedded_dark_mode_keeps_text_and_controls_readable():
+    css = (ROOT / "frontend" / "dist" / "assets" / "dataset-editor.css").read_text(
+        encoding="utf-8"
+    )
+
+    embedded_shell = css.split(".de-shell-embedded {", 1)[1].split("}", 1)[0]
+    embedded_inputs = css.split(".de-shell-embedded .de-dataset-path,", 1)[1].split("}", 1)[0]
+    embedded_buttons = css.split(".de-shell-embedded button {", 1)[1].split("}", 1)[0]
+    embedded_primary = css.split(".de-shell-embedded .de-primary {", 1)[1].split("}", 1)[0]
+    embedded_cards = css.split(".de-shell-embedded .de-card,", 1)[1].split("}", 1)[0]
+
+    assert "color: var(--de-text)" in embedded_shell
+    assert "background: var(--de-input-bg)" in embedded_inputs
+    assert "color: var(--de-text)" in embedded_inputs
+    assert "background: var(--de-control-bg)" in embedded_buttons
+    assert "color: var(--de-control-text)" in embedded_buttons
+    assert "color: #fff" in embedded_primary
+    assert "color: var(--de-text)" in embedded_cards


### PR DESCRIPTION
## Summary

- Add an extra trigger-word control to the native dataset editor tagger panel, reusing the existing batch caption append API for the current filtered/selected scope.
- Fix embedded dataset editor text/control colors so dark mode does not produce white text on white inputs/buttons.
- Add regression coverage for trigger-word controls and embedded readability rules.

## Verification

- `venv\\Scripts\\python.exe -m pytest tests/test_dataset_editor_api.py` → 27 passed
- `git diff --check -- frontend/dist/assets/dataset-editor-entry.js frontend/dist/assets/dataset-editor.css frontend/dist/assets/dataset-editor.js frontend/dist/dataset-editor.html tests/test_dataset_editor_api.py`
- Browser smoke via local static server:
  - `/dataset-editor.html` shows the extra trigger-word input and readable controls.
  - `/tageditor.html` embedded editor reports readable computed colors for trigger input, primary button, secondary button, panel, and tagger tab.