### PR TITLE
fix(anima-fast): support Linux environment install

### DIFF
--- a/config/anima_fast_environment/anima-constraints-cu130.txt
+++ b/config/anima_fast_environment/anima-constraints-cu130.txt
@@ -1,9 +1,11 @@
 # Real-test Anima Fast extension environment guard.
 # This environment is intentionally independent from the main GUI venv.
-torch==2.11.0+cu130
-torchvision==0.26.0+cu130
+torch==2.11.0+cu130 ; sys_platform == "win32"
+torchvision==0.26.0+cu130 ; sys_platform == "win32"
+torch==2.12.0+cu130 ; sys_platform == "linux"
+torchvision==0.27.0+cu130 ; sys_platform == "linux"
 flash-attn==2.8.3+cu130torch2.11
-triton-windows==3.7.0.post26
+triton-windows==3.7.0.post26 ; sys_platform == "win32"
 transformers==5.9.0
 diffusers==0.37.1
 accelerate==1.13.0

--- a/config/anima_fast_environment/anima-overrides-cu130.txt
+++ b/config/anima_fast_environment/anima-overrides-cu130.txt
@@ -1,3 +1,4 @@
 # sam3 declares numpy<2, while current anima_lora requires numpy>=2.
 # The existing Anima runtime validated in this real test uses NumPy 2.x.
 numpy>=2.0.0
+opencv-python-headless==4.13.0.92 ; sys_platform == "linux"

--- a/mikazuki/anima_fast_backend/environment.py
+++ b/mikazuki/anima_fast_backend/environment.py
@@ -31,6 +31,12 @@ ENVIRONMENT_DIR = Path("config/anima_fast_environment")
 ANIMA_CONSTRAINTS = ENVIRONMENT_DIR / "anima-constraints-cu130.txt"
 ANIMA_OVERRIDES = ENVIRONMENT_DIR / "anima-overrides-cu130.txt"
 MAIN_CONSTRAINTS = ENVIRONMENT_DIR / "main-constraints-cu130.txt"
+FLASH_ATTN_WINDOWS_MARKER = "flash-attn @ https://"
+FLASH_ATTN_LINUX_PLATFORM_MARKER = "sys_platform == 'linux'"
+FLASH_ATTN_LINUX_CU130_URL = (
+    "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.4/"
+    "flash_attn-2.8.3%2Bcu130torch2.11-cp313-cp313-linux_x86_64.whl"
+)
 
 ANIMA_OPTIMIZER_PACKAGES = {
     "bitsandbytes": "0.49.2",
@@ -76,11 +82,21 @@ ANIMA_EXPECTED = {
     },
 }
 
+ANIMA_LINUX_EXACT_OVERRIDES = {
+    "torch": "2.12.0+cu130",
+    "torchvision": "0.27.0+cu130",
+}
+
+ANIMA_WINDOWS_ONLY_EXACT = {"triton-windows"}
+
 MAIN_EXPECTED = {
     "python_major_minor": None,
     "exact": {
         "numpy": "1.26.4",
         "opencv-python": "4.8.1.78",
+    },
+    "alternatives": {
+        "opencv-python": ["opencv-python-headless"],
     },
 }
 
@@ -148,7 +164,12 @@ def build_environment_install_plan(
     root = project_root.resolve()
     extension_root = _resolve_child(root, layout.root)
     python_dir = _resolve_child(root, root / ".python")
-    base_python = python_dir / "cpython-3.13.13-windows-x86_64-none" / "python.exe"
+    if sys.platform == "win32":
+        base_python = python_dir / "cpython-3.13.13-windows-x86_64-none" / "python.exe"
+        venv_python = extension_root / ".venv" / "Scripts" / "python.exe"
+    else:
+        base_python = python_dir / "cpython-3.13.13-linux-x86_64-gnu" / "bin" / "python3"
+        venv_python = extension_root / ".venv" / "bin" / "python"
     env_dir = root / ENVIRONMENT_DIR
     constraints = env_dir / ANIMA_CONSTRAINTS.name
     overrides = env_dir / ANIMA_OVERRIDES.name
@@ -159,7 +180,7 @@ def build_environment_install_plan(
         source_commit=source_commit,
         python_install_dir=python_dir,
         base_python=base_python,
-        venv_python=extension_root / ".venv" / "Scripts" / "python.exe",
+        venv_python=venv_python,
         constraints=constraints,
         overrides=overrides,
         dry_run=dry_run,
@@ -168,6 +189,52 @@ def build_environment_install_plan(
 
 def _append(log: LogFn, line: str) -> None:
     log(line)
+
+
+def _replace_flash_attn_dependency(source_root: Path, platform_marker: str, replacement: str, log: LogFn) -> list[str]:
+    pyproject = source_root / "pyproject.toml"
+    if not pyproject.is_file():
+        return []
+    lines = pyproject.read_text(encoding="utf-8").splitlines(keepends=True)
+    changed: list[str] = []
+    patched: list[str] = []
+    for line in lines:
+        stripped = line.lstrip()
+        if (
+            not stripped.startswith("#")
+            and FLASH_ATTN_WINDOWS_MARKER in line
+            and platform_marker in line
+        ):
+            indent = line[: len(line) - len(stripped)]
+            patched.append(indent + replacement + ("\n" if line.endswith("\n") else ""))
+            changed.append(line.strip())
+            continue
+        patched.append(line)
+    if changed:
+        pyproject.write_text("".join(patched), encoding="utf-8")
+        for dependency in changed:
+            _append(log, f"[patch] localized Linux cu130 flash-attn dependency: {dependency}")
+    return changed
+
+
+def localize_linux_flash_attn_dependency(source_root: Path, log: LogFn = print) -> list[str]:
+    if not sys.platform.startswith("linux"):
+        return []
+    replacement = f'"flash-attn @ {FLASH_ATTN_LINUX_CU130_URL} ; {FLASH_ATTN_LINUX_PLATFORM_MARKER}",'
+    return _replace_flash_attn_dependency(source_root, FLASH_ATTN_LINUX_PLATFORM_MARKER, replacement, log)
+
+
+def _anima_expected_for_platform(platform: str | None = None) -> dict:
+    platform = platform or sys.platform
+    expected = {
+        "python_major_minor": ANIMA_EXPECTED["python_major_minor"],
+        "exact": dict(ANIMA_EXPECTED["exact"]),
+    }
+    if platform.startswith("linux"):
+        for package in ANIMA_WINDOWS_ONLY_EXACT:
+            expected["exact"].pop(package, None)
+        expected["exact"].update(ANIMA_LINUX_EXACT_OVERRIDES)
+    return expected
 
 
 def _run_streaming_once(command: list[str], cwd: Path, log: LogFn, env: dict[str, str] | None = None) -> None:
@@ -245,6 +312,9 @@ def install_environment(plan: EnvironmentInstallPlan, log: LogFn = print) -> Aud
     if plan.source_commit:
         _append(log, f"[source] pinned commit {plan.source_commit}")
     copy_source_snapshot(build_install_plan(plan.source_root, plan.layout, dry_run=False, source_commit=plan.source_commit))
+    localized_direct_urls = localize_linux_flash_attn_dependency(plan.layout.source, log)
+    if localized_direct_urls:
+        facts["localized_direct_url_dependencies"] = localized_direct_urls
 
     if not plan.constraints.is_file():
         raise FileNotFoundError(f"Anima constraints file missing: {plan.constraints}")
@@ -408,7 +478,26 @@ def _check_facts(
         errors.append(f"{label}: expected Python {major_minor}.x, got {facts.get('version') or 'unknown'}")
     for package, version in expected["exact"].items():
         actual = facts.get("packages", {}).get(package)
-        if actual != version:
+        if actual == version:
+            continue
+        alternatives = expected.get("alternatives", {}).get(package, [])
+        matched_alternative = next(
+            (
+                alternative
+                for alternative in alternatives
+                if facts.get("packages", {}).get(alternative) == version
+            ),
+            None,
+        )
+        if matched_alternative:
+            continue
+        if alternatives:
+            detail = ", ".join(
+                f"{name}={facts.get('packages', {}).get(name)}"
+                for name in [package, *alternatives]
+            )
+            errors.append(f"{label}: {package} expected {version} or equivalent, got {detail}")
+        else:
             errors.append(f"{label}: {package} expected {version}, got {actual}")
     if require_cuda and not facts.get("torch_cuda_available"):
         errors.append(f"{label}: torch.cuda is not available")
@@ -418,7 +507,10 @@ def _check_facts(
 
 
 def _main_facts_in_process() -> dict:
-    packages = {name: None for name in MAIN_EXPECTED["exact"]}
+    package_names = set(MAIN_EXPECTED["exact"])
+    for alternatives in MAIN_EXPECTED.get("alternatives", {}).values():
+        package_names.update(alternatives)
+    packages = {name: None for name in sorted(package_names)}
     for name in packages:
         try:
             packages[name] = importlib.metadata.version(name)
@@ -467,14 +559,15 @@ def audit_environment(
     main_python = main_python or Path(sys.executable)
     main_facts = _main_facts_in_process() if main_python.resolve() == Path(sys.executable).resolve() else _collect_python_facts(
         main_python,
-        sorted(MAIN_EXPECTED["exact"]),
+        sorted(set(MAIN_EXPECTED["exact"]) | {name for names in MAIN_EXPECTED.get("alternatives", {}).values() for name in names}),
         ["cv2", "torch"],
         root,
     )
+    anima_expected = _anima_expected_for_platform()
     anima_facts = (
         _collect_python_facts(
             layout.venv_python,
-            sorted(set(ANIMA_EXPECTED["exact"]) | {"numpy", "opencv-python"}),
+            sorted(set(anima_expected["exact"]) | {"numpy", "opencv-python"}),
             ["torch", "flash_attn", "triton", "transformers", "diffusers", *ANIMA_OPTIMIZER_IMPORTS],
             layout.source if layout.source.is_dir() else root,
         )
@@ -482,7 +575,7 @@ def audit_environment(
         else {"subprocess_error": "missing", "python": str(layout.venv_python)}
     )
     _check_facts("main", main_facts, MAIN_EXPECTED, root, errors, require_cuda=False, require_inside_root=require_main_inside_root)
-    _check_facts("anima", anima_facts, ANIMA_EXPECTED, root, errors, require_cuda=require_cuda, require_inside_root=True)
+    _check_facts("anima", anima_facts, anima_expected, root, errors, require_cuda=require_cuda, require_inside_root=True)
     result = AuditResult(
         ok=not errors,
         errors=errors,

--- a/tests/test_anima_fast_environment_installer.py
+++ b/tests/test_anima_fast_environment_installer.py
@@ -14,6 +14,7 @@ from mikazuki.anima_fast_backend.environment import (
     audit_environment,
     build_environment_install_plan,
     install_environment,
+    localize_linux_flash_attn_dependency,
     _run_streaming,
     start_install_task,
 )
@@ -44,6 +45,19 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
         env_dir.mkdir(parents=True)
         (env_dir / "anima-constraints-cu130.txt").write_text("torch==2.11.0+cu130\n", encoding="utf-8")
         (env_dir / "anima-overrides-cu130.txt").write_text("numpy>=2\n", encoding="utf-8")
+
+    def test_install_plan_uses_linux_python_layout_off_windows(self):
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "mikazuki.anima_fast_backend.environment.sys.platform", "linux"
+        ):
+            project = Path(td)
+            source = self._make_source(project)
+            layout = ExtensionLayout(project / "extensions" / "anima_lora")
+
+            plan = build_environment_install_plan(project, layout, source)
+
+        self.assertTrue(str(plan.base_python).replace("\\", "/").endswith("cpython-3.13.13-linux-x86_64-gnu/bin/python3"))
+        self.assertTrue(str(plan.venv_python).replace("\\", "/").endswith("extensions/anima_lora/.venv/bin/python"))
 
     def test_ready_requires_audit_ok_facts(self):
         with tempfile.TemporaryDirectory() as td:
@@ -243,6 +257,113 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
         text = constraints.read_text(encoding="utf-8")
         for package in ("bitsandbytes==0.49.2", "dadaptation==3.1", "lion-pytorch==0.2.3", "prodigyopt==1.1.2"):
             self.assertIn(package, text)
+
+    def test_anima_constraints_scope_linux_fast_runtime_packages_by_platform(self):
+        constraints = Path(__file__).resolve().parents[1] / "config" / "anima_fast_environment" / "anima-constraints-cu130.txt"
+        text = constraints.read_text(encoding="utf-8")
+
+        self.assertIn('torch==2.11.0+cu130 ; sys_platform == "win32"', text)
+        self.assertIn('torchvision==0.26.0+cu130 ; sys_platform == "win32"', text)
+        self.assertIn('torch==2.12.0+cu130 ; sys_platform == "linux"', text)
+        self.assertIn('torchvision==0.27.0+cu130 ; sys_platform == "linux"', text)
+        self.assertIn('triton-windows==3.7.0.post26 ; sys_platform == "win32"', text)
+
+    def test_anima_expected_packages_skip_triton_windows_on_linux(self):
+        from mikazuki.anima_fast_backend.environment import _anima_expected_for_platform
+
+        linux_expected = _anima_expected_for_platform("linux")
+        windows_expected = _anima_expected_for_platform("win32")
+
+        self.assertEqual(linux_expected["exact"]["torch"], "2.12.0+cu130")
+        self.assertEqual(linux_expected["exact"]["torchvision"], "0.27.0+cu130")
+        self.assertNotIn("triton-windows", linux_expected["exact"])
+        self.assertEqual(windows_expected["exact"]["torch"], "2.11.0+cu130")
+        self.assertEqual(windows_expected["exact"]["torchvision"], "0.26.0+cu130")
+        self.assertEqual(windows_expected["exact"]["triton-windows"], "3.7.0.post26")
+
+    def test_anima_overrides_use_headless_opencv_on_linux(self):
+        overrides = Path(__file__).resolve().parents[1] / "config" / "anima_fast_environment" / "anima-overrides-cu130.txt"
+        text = overrides.read_text(encoding="utf-8")
+
+        self.assertIn('opencv-python-headless==4.13.0.92 ; sys_platform == "linux"', text)
+
+    def test_localize_linux_flash_attn_dependency_uses_cu130_direct_url(self):
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "mikazuki.anima_fast_backend.environment.sys.platform", "linux"
+        ):
+            source = Path(td) / "source"
+            source.mkdir()
+            pyproject = source / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\ndependencies = [\n'
+                '    "flash-attn @ https://example.invalid/linux-cu132.whl ; sys_platform == \'linux\'",\n'
+                '    "flash-attn @ https://example.invalid/windows.whl ; sys_platform == \'win32\'",\n'
+                ']\n',
+                encoding="utf-8",
+            )
+            lines: list[str] = []
+
+            changed = localize_linux_flash_attn_dependency(source, lines.append)
+            text = pyproject.read_text(encoding="utf-8")
+
+        self.assertEqual(len(changed), 1)
+        self.assertIn("flash_attn-2.8.3%2Bcu130torch2.11-cp313-cp313-linux_x86_64.whl", text)
+        self.assertIn("windows.whl", text)
+        self.assertTrue(any("localized Linux cu130 flash-attn" in line for line in lines))
+
+    def test_audit_environment_skips_triton_windows_on_linux(self):
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "mikazuki.anima_fast_backend.environment.sys.platform", "linux"
+        ):
+            project = Path(td)
+            layout = ExtensionLayout(project / "extensions" / "anima_lora")
+            layout.source.mkdir(parents=True)
+            layout.train_py.write_text("", encoding="utf-8")
+            layout.venv_python.parent.mkdir(parents=True)
+            layout.venv_python.write_text("", encoding="utf-8")
+
+            def fake_collect(python, packages, imports, cwd):
+                package_facts = {name: "unused" for name in packages}
+                package_facts.update(
+                    {
+                        "torch": "2.12.0+cu130",
+                        "torchvision": "0.27.0+cu130",
+                        "flash-attn": "2.8.3+cu130torch2.11",
+                        "transformers": "5.9.0",
+                        "diffusers": "0.37.1",
+                        "accelerate": "1.13.0",
+                        "safetensors": "0.7.0",
+                        "iopath": "0.1.10",
+                        "bitsandbytes": "0.49.2",
+                        "dadaptation": "3.1",
+                    }
+                )
+                return {
+                    "python": str(python),
+                    "version": "3.13.13",
+                    "prefix": str(layout.venv_python.parent.parent),
+                    "base_prefix": str(project / ".python"),
+                    "packages": package_facts,
+                    "imports": {name: True for name in imports},
+                    "torch_cuda_available": True,
+                }
+
+            with mock.patch("mikazuki.anima_fast_backend.environment._collect_python_facts", side_effect=fake_collect), \
+                mock.patch(
+                    "mikazuki.anima_fast_backend.environment._main_facts_in_process",
+                    return_value={
+                        "python": str(project / ".venv" / "bin" / "python"),
+                        "version": "3.13.13",
+                        "prefix": str(project / ".venv"),
+                        "base_prefix": str(project / ".python"),
+                        "packages": {"numpy": "1.26.4", "opencv-python": None, "opencv-python-headless": "4.8.1.78"},
+                        "imports": {"cv2": True, "torch": True},
+                    },
+                ):
+                result = audit_environment(project, layout, require_cuda=True)
+
+        self.assertTrue(result.ok, result.errors)
+        self.assertNotIn("triton-windows", result.facts["anima"]["packages"])
 
     def test_anima_pip_dependency_targets_include_optimizer_and_quanto(self):
         targets = anima_pip_dependency_targets()


### PR DESCRIPTION
## Summary
- Scope Anima Fast CUDA constraints by platform so Linux uses torch 2.12 / torchvision 0.27 while Windows keeps the existing torch 2.11 runtime.
- Skip Windows-only `triton-windows` in Linux audits and use Linux venv/python paths.
- Localize the copied Anima source Linux `flash-attn` dependency to the cu130 direct wheel URL and allow headless OpenCV for Linux runtime compatibility.

## Tests
- `python -m pytest tests/test_anima_fast_environment_installer.py tests/test_anima_fast_backend.py tests/test_anima_fast_plugin_api.py -q`
- `git diff --check`