### PR TITLE
fix(train): limit image scan for CPU thread heuristic

### DIFF
--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -555,7 +555,7 @@ async def create_toml_file(request: Request):
             log.error(f"Anima Fast launch failed: {exc}")
             return APIResponseFail(message=f"Anima Fast launch failed: {exc}")
 
-    suggest_cpu_threads = 8 if len(train_utils.get_total_images(config["train_data_dir"])) > 200 else 2
+    suggest_cpu_threads = 8 if len(train_utils.get_total_images(config["train_data_dir"], limit=200)) >= 200 else 2
     trainer_file = trainer_mapping[model_train_type]
     apply_sdxl_prediction_type(config, model_train_type)
     apply_anima_training_defaults(config, model_train_type)

--- a/mikazuki/utils/train_utils.py
+++ b/mikazuki/utils/train_utils.py
@@ -311,7 +311,34 @@ def check_training_params(data):
     return True
 
 
-def get_total_images(path, recursive=True):
+def get_total_images(path, recursive=True, limit=None):
+    if limit is not None:
+        limit = int(limit)
+        if limit <= 0:
+            return []
+        if not os.path.isdir(path):
+            return []
+        image_files = []
+        image_suffixes = {".jpg", ".jpeg", ".png"}
+        if recursive:
+            for root, _, files in os.walk(path):
+                for name in files:
+                    if os.path.splitext(name)[1].lower() not in image_suffixes:
+                        continue
+                    image_files.append(os.path.join(root, name))
+                    if len(image_files) >= limit:
+                        return image_files
+        else:
+            for entry in os.scandir(path):
+                if not entry.is_file():
+                    continue
+                if os.path.splitext(entry.name)[1].lower() not in image_suffixes:
+                    continue
+                image_files.append(entry.path)
+                if len(image_files) >= limit:
+                    return image_files
+        return image_files
+
     if recursive:
         image_files = glob.glob(path + '/**/*.jpg', recursive=True)
         image_files += glob.glob(path + '/**/*.jpeg', recursive=True)

--- a/tests/test_train_utils_image_scan.py
+++ b/tests/test_train_utils_image_scan.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mikazuki.utils import train_utils  # noqa: E402
+
+
+def test_get_total_images_stops_at_limit(tmp_path):
+    for index in range(250):
+        (tmp_path / f"{index:03d}.png").write_bytes(b"")
+
+    images = train_utils.get_total_images(str(tmp_path), limit=200)
+
+    assert len(images) == 200
+
+
+def test_get_total_images_with_limit_returns_empty_for_missing_path(tmp_path):
+    images = train_utils.get_total_images(str(tmp_path / "missing"), limit=200)
+
+    assert images == []
+
+
+def test_get_total_images_with_limit_returns_empty_for_missing_non_recursive_path(tmp_path):
+    images = train_utils.get_total_images(str(tmp_path / "missing"), recursive=False, limit=200)
+
+    assert images == []


### PR DESCRIPTION
## Summary
- add an optional limit to training image discovery
- use a 200-image cap when choosing suggested CPU threads before standard training submit
- keep missing-path behavior safe for limited scans

## Tests
- pytest tests\\test_train_utils_image_scan.py
- python -m py_compile mikazuki\\utils\\train_utils.py mikazuki\\app\\api.py
- git diff --check

Note: broader related tests could not run in this local environment because dependencies/config are mismatched: missing toml for sd-scripts and httpx AsyncClient no longer accepting proxies in the installed version.