### PR TITLE
fix(anima-fast): prefer extension venv runtime on Linux

### DIFF
--- a/mikazuki/anima_fast_backend/settings.py
+++ b/mikazuki/anima_fast_backend/settings.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 import os
+import sys
 try:
     import tomllib
 except ModuleNotFoundError:  # Python 3.10 runtime
     import toml as tomllib
+
+from .extension_state import default_layout
 
 
 DEFAULT_CONFIG = Path("config/anima_fast_backend.toml")
@@ -39,6 +42,12 @@ def _truthy(value: object) -> bool:
     if isinstance(value, bool):
         return value
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _venv_python_for_root(root: Path) -> Path:
+    if sys.platform == "win32":
+        return root / ".venv" / "Scripts" / "python.exe"
+    return root / ".venv" / "bin" / "python"
 
 
 def repo_root() -> Path:
@@ -80,9 +89,11 @@ def discover_runtime(config: dict | None = None, lora_next_root: Path | None = N
     config = config or load_backend_config(lora_next_root)
     backend = config.get("backend", {})
     paths = config.get("paths", {})
+    layout = default_layout(lora_next_root)
 
     extension_source = _as_path(backend.get("source_dir"), lora_next_root)
     extension_python = _as_path(backend.get("venv_python"), lora_next_root)
+    layout_python = layout.venv_python.resolve()
     external_root = _as_path(backend.get("external_root"), lora_next_root)
     external_python = _as_path(backend.get("external_python"), lora_next_root)
 
@@ -92,11 +103,13 @@ def discover_runtime(config: dict | None = None, lora_next_root: Path | None = N
         or external_root
         or (lora_next_root.parent / "anima_lora").resolve()
     )
+    fallback_python = layout_python if root.resolve() == layout.source.resolve() else _venv_python_for_root(root).resolve()
     python = (
         _as_path(os.environ.get("ANIMA_LORA_PYTHON"), lora_next_root)
         or (extension_python if extension_python and extension_python.is_file() else None)
+        or (layout_python if layout_python.is_file() else None)
         or external_python
-        or (root / ".venv" / "Scripts" / "python.exe").resolve()
+        or fallback_python
     )
 
     return RuntimeConfig(

--- a/tests/test_anima_fast_settings.py
+++ b/tests/test_anima_fast_settings.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from mikazuki.anima_fast_backend.extension_state import ExtensionLayout
+from mikazuki.anima_fast_backend.settings import discover_runtime
+
+
+class AnimaFastSettingsTests(unittest.TestCase):
+    def test_discover_runtime_prefers_linux_extension_venv_when_config_has_windows_path(self):
+        with tempfile.TemporaryDirectory() as td, mock.patch(
+            "mikazuki.anima_fast_backend.extension_state.sys.platform", "linux"
+        ):
+            root = Path(td)
+            layout = ExtensionLayout(root / "extensions" / "anima_lora")
+            layout.source.mkdir(parents=True)
+            layout.train_py.write_text("", encoding="utf-8")
+            layout.venv_python.parent.mkdir(parents=True)
+            layout.venv_python.write_text("", encoding="utf-8")
+            expected_python = layout.venv_python.resolve()
+            external = root / "external_anima"
+            external.mkdir()
+            (external / "train.py").write_text("", encoding="utf-8")
+            ext_py = external / ".venv" / "Scripts" / "python.exe"
+            ext_py.parent.mkdir(parents=True)
+            ext_py.write_text("", encoding="utf-8")
+            config_path = root / "config" / "anima_fast_backend.toml"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "[backend]",
+                        'source_dir = "extensions/anima_lora/source"',
+                        'venv_python = "extensions/anima_lora/.venv/Scripts/python.exe"',
+                        f'external_root = "{external.as_posix()}"',
+                        f'external_python = "{ext_py.as_posix()}"',
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            runtime = discover_runtime(lora_next_root=root)
+
+        self.assertEqual(runtime.python.resolve(), expected_python)


### PR DESCRIPTION
## Summary
- fix Anima Fast runtime discovery so the installed extension venv is preferred when present
- use platform-aware venv fallbacks instead of hard-coding .venv/Scripts/python.exe
- add a Linux regression test for stale Windows venv_python config plus external runtime fallback

Fixes #88.

## Tests
- PYTHONPATH=. pytest tests\\test_anima_fast_environment_installer.py tests\\test_anima_fast_settings.py
- python -m py_compile mikazuki\\anima_fast_backend\\settings.py tests\\test_anima_fast_settings.py
- git diff --check