### PR TITLE
fix(anima-fast): preserve Linux venv launcher

### DIFF
--- a/mikazuki/anima_fast_backend/settings.py
+++ b/mikazuki/anima_fast_backend/settings.py
@@ -38,6 +38,15 @@ def _as_path(value: str | os.PathLike | None, base: Path) -> Path | None:
     return path.resolve()
 
 
+def _as_launcher_path(value: str | os.PathLike | None, base: Path) -> Path | None:
+    if value is None or str(value).strip() == "":
+        return None
+    path = Path(value)
+    if not path.is_absolute():
+        path = base / path
+    return path
+
+
 def _truthy(value: object) -> bool:
     if isinstance(value, bool):
         return value
@@ -92,10 +101,10 @@ def discover_runtime(config: dict | None = None, lora_next_root: Path | None = N
     layout = default_layout(lora_next_root)
 
     extension_source = _as_path(backend.get("source_dir"), lora_next_root)
-    extension_python = _as_path(backend.get("venv_python"), lora_next_root)
-    layout_python = layout.venv_python.resolve()
+    extension_python = _as_launcher_path(backend.get("venv_python"), lora_next_root)
+    layout_python = layout.venv_python
     external_root = _as_path(backend.get("external_root"), lora_next_root)
-    external_python = _as_path(backend.get("external_python"), lora_next_root)
+    external_python = _as_launcher_path(backend.get("external_python"), lora_next_root)
 
     root = (
         (extension_source if extension_source and (extension_source / "train.py").is_file() else None)
@@ -103,12 +112,12 @@ def discover_runtime(config: dict | None = None, lora_next_root: Path | None = N
         or external_root
         or (lora_next_root.parent / "anima_lora").resolve()
     )
-    fallback_python = layout_python if root.resolve() == layout.source.resolve() else _venv_python_for_root(root).resolve()
+    fallback_python = layout_python if root.resolve() == layout.source.resolve() else _venv_python_for_root(root)
     python = (
-        _as_path(os.environ.get("ANIMA_LORA_PYTHON"), lora_next_root)
+        _as_launcher_path(os.environ.get("ANIMA_LORA_PYTHON"), lora_next_root)
         or (extension_python if extension_python and extension_python.is_file() else None)
         or (layout_python if layout_python.is_file() else None)
-        or external_python
+        or (external_python if external_python and external_python.is_file() else None)
         or fallback_python
     )
 

--- a/tests/test_anima_fast_plugin_api.py
+++ b/tests/test_anima_fast_plugin_api.py
@@ -76,7 +76,37 @@ class AnimaFastPluginApiTests(unittest.TestCase):
             )
             runtime = discover_runtime(lora_next_root=root)
 
-        self.assertEqual(runtime.python.resolve(), layout.venv_python.resolve())
+        self.assertEqual(runtime.python, layout.venv_python)
+
+    def test_discover_runtime_keeps_linux_uv_venv_launcher_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            layout = ExtensionLayout(root / "extensions" / "anima_lora")
+            base_python = root / ".python" / "cpython-3.13.13-linux-x86_64-gnu" / "bin" / "python3.13"
+            base_python.parent.mkdir(parents=True)
+            base_python.write_text("", encoding="utf-8")
+
+            with mock.patch("mikazuki.anima_fast_backend.settings.sys.platform", "linux"), \
+                mock.patch("mikazuki.anima_fast_backend.extension_state.sys.platform", "linux"):
+                layout.source.mkdir(parents=True)
+                layout.train_py.write_text("", encoding="utf-8")
+                layout.venv_python.parent.mkdir(parents=True)
+                layout.venv_python.write_text("", encoding="utf-8")
+                original_resolve = Path.resolve
+
+                def fake_resolve(path: Path, *args, **kwargs):
+                    if path == layout.venv_python:
+                        return base_python
+                    return original_resolve(path, *args, **kwargs)
+
+                with mock.patch("pathlib.Path.resolve", fake_resolve):
+                    runtime = discover_runtime(lora_next_root=root)
+
+                expected = layout.venv_python
+
+        self.assertEqual(runtime.python, expected)
+        self.assertIn(".venv", runtime.python.parts)
+        self.assertNotEqual(runtime.python, base_python)
 
     def test_install_starts_background_task_and_returns_log_stream(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

Fixes #91.

Linux uv venvs expose `.venv/bin/python` as a launcher/symlink into the managed base CPython. `discover_runtime()` now preserves Python launcher paths instead of resolving them, so Anima Fast subprocesses keep the venv `site-packages` for PIL, torch, and other plugin dependencies.

The change also keeps `external_python` behind an `is_file()` check and adds a Linux regression test that simulates `.venv/bin/python` resolving to `.python/cpython.../bin/python3.13`.

## Test Plan

- `python -c "import asyncio, pytest; asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy()); raise SystemExit(pytest.main(['tests/test_anima_fast_plugin_api.py','tests/test_anima_fast_preprocess.py','tests/test_anima_fast_backend.py']))"`

Result: 42 passed.