### PR TITLE
fix(train-log): strip ANSI escape codes

### DIFF
--- a/mikazuki/anima_fast_backend/launcher.py
+++ b/mikazuki/anima_fast_backend/launcher.py
@@ -26,6 +26,9 @@ def build_launch_spec(runtime: RuntimeConfig, config_path: Path, task_id: str, g
     env["PYTHONUNBUFFERED"] = "1"
     env["PYTHONNOUSERSITE"] = "1"
     env["ACCELERATE_DISABLE_RICH"] = "1"
+    env["NO_COLOR"] = "1"
+    env["FORCE_COLOR"] = "0"
+    env["TERM"] = "dumb"
     env["ANIMA_FAST_PARENT_TASK_ID"] = task_id
     env.pop("PYTHONPATH", None)
     if runtime.hf_home is not None:

--- a/mikazuki/process.py
+++ b/mikazuki/process.py
@@ -94,6 +94,9 @@ def build_accelerate_train_command(
     customize_env["PYTHONUNBUFFERED"] = "1"
     customize_env["PYTHONWARNINGS"] = "ignore::FutureWarning,ignore::UserWarning"
     customize_env["PYTHONNOUSERSITE"] = "1"
+    customize_env["NO_COLOR"] = "1"
+    customize_env["FORCE_COLOR"] = "0"
+    customize_env["TERM"] = "dumb"
 
     if gpu_ids:
         customize_env["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_ids)

--- a/mikazuki/train_log_hub.py
+++ b/mikazuki/train_log_hub.py
@@ -5,10 +5,21 @@ Buffers training subprocess stdout per task_id for SSE streaming and optional UI
 from __future__ import annotations
 
 import threading
+import re
 from collections import deque
 from typing import Deque, Dict, List, Tuple
 
 _MAX_LINES = 15000
+_ANSI_ESCAPE_RE = re.compile(
+    r"\x1B\][^\x07]*?(?:\x07|\x1B\\)|"
+    r"\x1B\[[0-?]*[ -/]*[@-~]|"
+    r"\x1B[@-Z\\-_]"
+)
+
+
+def strip_ansi(text: str) -> str:
+    """Remove terminal color/control codes before streaming logs to browsers."""
+    return _ANSI_ESCAPE_RE.sub("", text)
 
 
 class TrainLogHub:
@@ -25,7 +36,7 @@ class TrainLogHub:
             self._done[task_id] = False
 
     def append_line(self, task_id: str, line: str) -> None:
-        text = line.rstrip("\r\n")
+        text = strip_ansi(line.rstrip("\r\n"))
         if not text and line == "":
             return
         with self._lock:

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -566,6 +566,10 @@ class PreflightLauncherTests(unittest.TestCase):
         self.assertEqual(spec.env["PYTHONNOUSERSITE"], "1")
         self.assertNotIn("PYTHONPATH", spec.env)
         self.assertEqual(spec.env["CUDA_VISIBLE_DEVICES"], "0")
+        self.assertEqual(spec.env["ACCELERATE_DISABLE_RICH"], "1")
+        self.assertEqual(spec.env["NO_COLOR"], "1")
+        self.assertEqual(spec.env["FORCE_COLOR"], "0")
+        self.assertEqual(spec.env["TERM"], "dumb")
 
 
 if __name__ == "__main__":

--- a/tests/test_process_mixed_precision_launch.py
+++ b/tests/test_process_mixed_precision_launch.py
@@ -126,6 +126,20 @@ class BuildAccelerateTrainCommandTests(unittest.TestCase):
         self.assertLess(args.index("--multi_gpu"), args.index("--mixed_precision"))
         self.assertEqual(env["CUDA_VISIBLE_DEVICES"], "0,1")
 
+    def test_disables_colored_subprocess_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            toml_path = Path(tmp) / "train.toml"
+            toml_path.write_text('mixed_precision = "bf16"\n', encoding="utf-8")
+            _args, env, _mp = process.build_accelerate_train_command(
+                trainer_file="./scripts/stable/train_network.py",
+                toml_path=str(toml_path),
+            )
+
+        self.assertEqual(env["ACCELERATE_DISABLE_RICH"], "1")
+        self.assertEqual(env["NO_COLOR"], "1")
+        self.assertEqual(env["FORCE_COLOR"], "0")
+        self.assertEqual(env["TERM"], "dumb")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_train_log_hub.py
+++ b/tests/test_train_log_hub.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+
+from mikazuki.train_log_hub import TrainLogHub, strip_ansi
+
+
+class TrainLogHubAnsiTests(unittest.TestCase):
+    def test_strip_ansi_removes_colors_progress_and_hyperlinks(self):
+        raw = (
+            "\x1b[2;36m2026-06-05 15:21:06\x1b[0m "
+            "\x1b[34mINFO\x1b[0m "
+            "\x1b]8;;file:///tmp/train.py\x1b\\train.py\x1b]8;;\x1b\\ "
+            "steps: 0%|\x1b[34m \x1b[0m| 0/10"
+        )
+
+        self.assertEqual(
+            strip_ansi(raw),
+            "2026-06-05 15:21:06 INFO train.py steps: 0%| | 0/10",
+        )
+
+    def test_append_line_buffers_sanitized_text(self):
+        hub = TrainLogHub()
+        hub.start_task("task-ansi")
+
+        hub.append_line("task-ansi", "\x1b[34mINFO\x1b[0m running training\r\n")
+        hub.append_line("task-ansi", "\x1b]8;;file:///tmp/a.py\x1b\\a.py\x1b]8;;\x1b\\\n")
+
+        lines, total, done = hub.snapshot_from("task-ansi", 0)
+
+        self.assertEqual(lines, ["INFO running training", "a.py"])
+        self.assertEqual(total, 2)
+        self.assertFalse(done)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Training log panels now buffer browser-safe text when subprocesses emit Rich, tqdm, or terminal hyperlink escape sequences. The log hub strips ANSI CSI, OSC hyperlinks, and single-character ESC controls before SSE/tail consumers see each line.

The training environments also request plain output at the source by setting `NO_COLOR=1`, `FORCE_COLOR=0`, and `TERM=dumb` for both regular accelerate launches and Anima Fast launches.

## Test Plan

- `python -m pytest tests/test_train_log_hub.py tests/test_process_mixed_precision_launch.py`
- `python -m pytest tests/test_anima_fast_backend.py`

Note: running `test_process_mixed_precision_launch.py` before `test_anima_fast_backend.py` in the same pytest process still hits an existing test-stub isolation issue, so these were run separately.