### PR TITLE
fix(anima-fast): disable unsupported Automagic optimizer

### DIFF
--- a/docs/anima-fast-merge-checklist.md
+++ b/docs/anima-fast-merge-checklist.md
@@ -10,7 +10,7 @@
 | 插件安装复制上游 `LICENSE` / `NOTICE` | ✅ | `installer.py` → `INCLUDE_TOP_LEVEL` |
 | 用户文档致谢与仓库链接 | ✅ | `docs/anima-fast.md` §致谢；Fast 页 `anima-fast-credit` |
 | 本仓库 AGPL 与 upstream MIT 兼容 | ✅ | MIT 可嵌入；插件以独立目录分发，不修改上游许可 |
-| Automagic 等移植代码文件头 MIT 注明 | ✅ | `extensions/anima_lora/source/library/training/optimizers/`（插件快照内） |
+| Automagic 等额外优化器移植代码文件头 MIT 注明 | N/A | 当前 Fast 插件快照未接入 Automagic；UI/adapter 会拒绝 `optimizer_type=Automagic` |
 
 **关于是否告知上游作者**：MIT **不要求**事先征得作者同意；合规要点是**保留版权与许可声明**并在产品中**醒目致谢**（本仓已在 `NOTICE.md`、Fast 页、用户文档完成）。向 [sorryhyun/anima_lora](https://github.com/sorryhyun/anima_lora) 开 Discussion/Issue 仅为**礼节性可选**，作者若未回复也不影响合入与发布。
 

--- a/docs/anima-fast.md
+++ b/docs/anima-fast.md
@@ -257,7 +257,6 @@ Fast 页与标准 Kohya 页共用 **LR_OPTIMIZER** 选项（默认 `AdamW8bit`�
 | 优化器示例 | 依赖包 |
 |-----------|--------|
 | `AdamW8bit`、`PagedAdamW8bit`、`Lion8bit` 等 8bit | `bitsandbytes` |
-| **Automagic** | `optimum-quanto` |
 | `Lion` | `lion-pytorch` |
 | `Prodigy` | `prodigyopt` |
 | `DAdaptation` / `DAdaptAdam` 等 | `dadaptation` |
@@ -265,7 +264,7 @@ Fast 页与标准 Kohya 页共用 **LR_OPTIMIZER** 选项（默认 `AdamW8bit`�
 | `pytorch_optimizer.CAME` 等 | `pytorch-optimizer` |
 | `AdamW` | 无额外依赖（PyTorch 内置） |
 
-Fast 页优化器下拉**仅列出 anima_lora 已支持的选项**（不含 `prodigyplus.*` 等 Kohya 专用项）。Automagic 建议起始 `learning_rate=1e-6`。
+Fast 页优化器下拉**仅列出当前 anima_lora 插件快照已支持的选项**（不含 `prodigyplus.*` 等 Kohya 专用项）。当前 Fast 插件快照未接入 Automagic 优化器，若导入旧配置选择 `optimizer_type=Automagic`，后端会在启动前拒绝并提示改用 `AdamW8bit` 等 Fast 支持项。
 
 若报错 `ImportError: No bitsandbytes` 或 `libbitsandbytes_cuda130.dll not found`，说明插件是在补全优化器依赖前安装的，或 `bitsandbytes` 版本过旧（cu130 需 **≥ 0.49**）：在 Fast 页点击 **「修复插件」**（或 `POST /api/plugins/anima-lora/repair`）重新同步依赖。
 

--- a/mikazuki/anima_fast_backend/adapter.py
+++ b/mikazuki/anima_fast_backend/adapter.py
@@ -64,7 +64,6 @@ FAST_NETWORK_ARGS_ALLOWLIST = {
 FAST_SUPPORTED_OPTIMIZERS = {
     "AdamW",
     "AdamW8bit",
-    "Automagic",
     "PagedAdamW8bit",
     "RAdamScheduleFree",
     "Lion",
@@ -328,12 +327,15 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
 
     optimizer_type = str(values.get("optimizer_type", source.get("optimizer_type", "AdamW8bit"))).strip()
     if optimizer_type and optimizer_type not in FAST_SUPPORTED_OPTIMIZERS:
+        if optimizer_type == "Automagic":
+            raise AdapterError(
+                "optimizer_type=Automagic is not supported by the Anima Fast plugin runtime; "
+                "choose AdamW8bit or another Fast optimizer"
+            )
         raise AdapterError(
             f"optimizer_type={optimizer_type} is not supported by anima-lora-fast; "
             f"choose one of: {', '.join(sorted(FAST_SUPPORTED_OPTIMIZERS))}"
         )
-    if optimizer_type == "Automagic":
-        warnings.append("Automagic manages per-parameter learning rates; keep learning_rate near 1e-6")
 
     return AdaptedConfig(values=values, warnings=warnings)
 

--- a/mikazuki/anima_fast_backend/preflight.py
+++ b/mikazuki/anima_fast_backend/preflight.py
@@ -281,6 +281,13 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
     if torch_compile and tokens and static_token_count and tokens > static_token_count:
         errors.append(f"static_token_count={static_token_count} is smaller than resolution token count {tokens}")
 
+    optimizer_type = str(config.get("optimizer_type", "")).strip().lower()
+    if optimizer_type == "automagic":
+        errors.append(
+            "optimizer_type=Automagic is not supported by the Anima Fast plugin runtime; "
+            "use AdamW8bit or another Fast optimizer"
+        )
+
     cache_latents = _truthy(config.get("cache_latents"))
     cache_text_encoder = _truthy(config.get("cache_text_encoder_outputs"))
     skip_cache_check = _truthy(config.get("skip_cache_check"))
@@ -320,12 +327,6 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
             errors.append(
                 "torch package metadata is missing (dist-info corrupt); "
                 "repair the Anima Fast plugin before training"
-            )
-        optimizer_type = str(config.get("optimizer_type", "")).strip().lower()
-        if optimizer_type == "automagic" and not dep.quanto_importable:
-            errors.append(
-                "optimizer_type=Automagic 需要 Fast 插件环境安装 optimum-quanto；"
-                "请先在 Anima Fast 插件页修复环境，或改用 AdamW8bit"
             )
         if str(config.get("attn_mode", "")).strip() == "flash" and not dep.flash_attn_importable:
             errors.append(

--- a/mikazuki/schema/shared.ts
+++ b/mikazuki/schema/shared.ts
@@ -212,7 +212,6 @@
                 optimizer_type: Schema.union([
                     "AdamW",
                     "AdamW8bit",
-                    "Automagic",
                     "PagedAdamW8bit",
                     "RAdamScheduleFree",
                     "Lion",
@@ -238,14 +237,6 @@
                     optimizer_type: Schema.const('Prodigy').required(),
                     prodigy_d0: Schema.string(),
                     prodigy_d_coef: Schema.string().default("2.0"),
-                }),
-                Schema.object({}),
-            ]),
-
-            Schema.union([
-                Schema.object({
-                    optimizer_type: Schema.const('Automagic').required(),
-                    learning_rate: Schema.string().default("1e-6").description("Automagic 起始学习率，建议 1e-6 量级"),
                 }),
                 Schema.object({}),
             ]),

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -458,22 +458,24 @@ class PreflightLauncherTests(unittest.TestCase):
                     "run-1",
                 )
 
-    def test_adapt_config_accepts_automagic(self):
+    def test_adapt_config_rejects_automagic(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             runtime = make_runtime(root)
-            adapted = adapt_config(
-                {
-                    "model_train_type": "anima-lora-fast",
-                    "train_data_dir": str(root / "data"),
-                    "optimizer_type": "Automagic",
-                    "learning_rate": "1e-6",
-                },
-                runtime,
-                "run-1",
-            )
-        self.assertEqual(adapted.values["optimizer_type"], "Automagic")
-        self.assertTrue(any("Automagic" in w for w in adapted.warnings))
+            with self.assertRaises(AdapterError) as ctx:
+                adapt_config(
+                    {
+                        "model_train_type": "anima-lora-fast",
+                        "train_data_dir": str(root / "data"),
+                        "optimizer_type": "Automagic",
+                        "learning_rate": "1e-6",
+                    },
+                    runtime,
+                    "run-1",
+                )
+
+        self.assertIn("Automagic", str(ctx.exception))
+        self.assertIn("not supported", str(ctx.exception))
 
     def test_preflight_rejects_compile_mode_full_with_gradient_checkpointing(self):
         with tempfile.TemporaryDirectory() as td:
@@ -522,7 +524,7 @@ class PreflightLauncherTests(unittest.TestCase):
         self.assertEqual(adapted.values["compile_mode"], "blocks")
         self.assertTrue(any("gradient_checkpointing" in w for w in adapted.warnings))
 
-    def test_preflight_rejects_automagic_without_quanto(self):
+    def test_preflight_rejects_automagic_even_when_quanto_is_available(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             runtime = make_runtime(root)
@@ -548,12 +550,12 @@ class PreflightLauncherTests(unittest.TestCase):
                     "3.13.11",
                     torch_metadata_version="2.11.0+cu130",
                     cuda_available=True,
-                    quanto_importable=False,
+                    quanto_importable=True,
                 ),
             )
 
         self.assertFalse(result.ok)
-        self.assertTrue(any("Automagic" in err and "optimum-quanto" in err and "修复环境" in err for err in result.errors))
+        self.assertTrue(any("Automagic" in err and "not supported" in err for err in result.errors))
 
     def test_launcher_uses_external_python_and_isolated_env(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_anima_fast_integration_static.py
+++ b/tests/test_anima_fast_integration_static.py
@@ -12,9 +12,11 @@ class AnimaFastStaticIntegrationTests(unittest.TestCase):
 
         self.assertIn('default("anima-lora-fast")', schema)
         self.assertIn("ANIMA_FAST_LR_OPTIMIZER", schema)
-        self.assertIn('"Automagic"', shared)
-        self.assertNotIn("prodigyplus.ProdigyPlusScheduleFree", shared[shared.index("ANIMA_FAST_LR_OPTIMIZER"):])
-        self.assertNotIn('"EmoSens"', shared[shared.index("ANIMA_FAST_LR_OPTIMIZER"):])
+        fast_optimizer = shared[shared.index("ANIMA_FAST_LR_OPTIMIZER"):]
+        self.assertIn('"Automagic"', shared[: shared.index("ANIMA_FAST_LR_OPTIMIZER")])
+        self.assertNotIn('"Automagic"', fast_optimizer)
+        self.assertNotIn("prodigyplus.ProdigyPlusScheduleFree", fast_optimizer)
+        self.assertNotIn('"EmoSens"', fast_optimizer)
         self.assertIn('"EmoSens"', shared[: shared.index("ANIMA_FAST_LR_OPTIMIZER")])
         self.assertIn('Schema.const("lora")', schema)
 
@@ -22,6 +24,7 @@ class AnimaFastStaticIntegrationTests(unittest.TestCase):
         adapter = Path("mikazuki/anima_fast_backend/adapter.py").read_text(encoding="utf-8")
         self.assertIn("FAST_SUPPORTED_OPTIMIZERS", adapter)
         self.assertNotIn('"EmoSens"', adapter)
+        self.assertNotIn('"Automagic",', adapter[adapter.index("FAST_SUPPORTED_OPTIMIZERS"): adapter.index("@dataclass")])
 
     def test_fast_train_type_is_not_legacy_trainer_mapping(self):
         source = Path("mikazuki/app/api.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Removes `Automagic` from the Anima Fast optimizer schema because the packaged `anima_lora` runtime does not wire that optimizer yet.
- Rejects imported Fast configs that still set `optimizer_type=Automagic` during adapter/preflight validation, so users get a clear setup-time error instead of a `torch.optim.Automagic` runtime crash.
- Updates Fast docs and static/backend tests to reflect the supported optimizer surface.

## Test plan

- `python -m pytest tests/test_anima_fast_backend.py tests/test_anima_fast_integration_static.py`

Fixes wochenlong/lora-scripts-next#96