### PR TITLE
fix(anima-fast): default DAdaptAdaGrad eps

### DIFF
--- a/docs/anima-fast.md
+++ b/docs/anima-fast.md
@@ -264,7 +264,7 @@ Fast 页与标准 Kohya 页共用 **LR_OPTIMIZER** 选项（默认 `AdamW8bit`�
 | `pytorch_optimizer.CAME` 等 | `pytorch-optimizer` |
 | `AdamW` | 无额外依赖（PyTorch 内置） |
 
-Fast 页优化器下拉**仅列出当前 anima_lora 插件快照已支持的选项**（不含 `prodigyplus.*` 等 Kohya 专用项）。当前 Fast 插件快照未接入 Automagic 优化器，若导入旧配置选择 `optimizer_type=Automagic`，后端会在启动前拒绝并提示改用 `AdamW8bit` 等 Fast 支持项。
+Fast 页优化器下拉**仅列出当前 anima_lora 插件快照已支持的选项**（不含 `prodigyplus.*` 等 Kohya 专用项）。当前 Fast 插件快照未接入 Automagic 优化器，若导入旧配置选择 `optimizer_type=Automagic`，后端会在启动前拒绝并提示改用 `AdamW8bit` 等 Fast 支持项。`DAdaptAdaGrad` 在 `dadaptation==3.1` 下默认 `eps=0.0` 会报错，Fast 会在用户未填写 `eps=` 时自动补充 `optimizer_args=["eps=1e-8"]`；需要实验其它值时可在自定义 optimizer_args 中显式填写。
 
 若报错 `ImportError: No bitsandbytes` 或 `libbitsandbytes_cuda130.dll not found`，说明插件是在补全优化器依赖前安装的，或 `bitsandbytes` 版本过旧（cu130 需 **≥ 0.49**）：在 Fast 页点击 **「修复插件」**（或 `POST /api/plugins/anima-lora/repair`）重新同步依赖。
 

--- a/mikazuki/anima_fast_backend/adapter.py
+++ b/mikazuki/anima_fast_backend/adapter.py
@@ -150,6 +150,18 @@ def normalize_kv_args(values: Any) -> list[str]:
     return out
 
 
+def has_kv_arg(values: Any, key: str) -> bool:
+    if not isinstance(values, list):
+        return False
+    expected = key.strip().lower()
+    for raw in values:
+        if isinstance(raw, str) and "=" in raw:
+            raw_key = raw.split("=", 1)[0].strip().lower()
+            if raw_key == expected:
+                return True
+    return False
+
+
 def normalize_fast_network_args(values: Any) -> list[str]:
     if not isinstance(values, list):
         return []
@@ -336,6 +348,9 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
             f"optimizer_type={optimizer_type} is not supported by anima-lora-fast; "
             f"choose one of: {', '.join(sorted(FAST_SUPPORTED_OPTIMIZERS))}"
         )
+    if optimizer_type == "DAdaptAdaGrad" and not has_kv_arg(values.get("optimizer_args"), "eps"):
+        values["optimizer_args"] = normalize_kv_args([*values.get("optimizer_args", []), "eps=1e-8"])
+        warnings.append("DAdaptAdaGrad 默认 eps=0.0 会被 dadaptation 3.1 拒绝；已自动补充 optimizer_args eps=1e-8")
 
     return AdaptedConfig(values=values, warnings=warnings)
 

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -477,6 +477,41 @@ class PreflightLauncherTests(unittest.TestCase):
         self.assertIn("Automagic", str(ctx.exception))
         self.assertIn("not supported", str(ctx.exception))
 
+    def test_adapt_config_adds_dadapt_adagrad_eps_default(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            adapted = adapt_config(
+                {
+                    "model_train_type": "anima-lora-fast",
+                    "train_data_dir": str(root / "data"),
+                    "optimizer_type": "DAdaptAdaGrad",
+                },
+                runtime,
+                "run-1",
+            )
+
+        self.assertIn("eps=1e-8", adapted.values["optimizer_args"])
+        self.assertTrue(any("DAdaptAdaGrad" in warning and "eps=1e-8" in warning for warning in adapted.warnings))
+
+    def test_adapt_config_keeps_user_dadapt_adagrad_eps(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            adapted = adapt_config(
+                {
+                    "model_train_type": "anima-lora-fast",
+                    "train_data_dir": str(root / "data"),
+                    "optimizer_type": "DAdaptAdaGrad",
+                    "optimizer_args_custom": ["eps=1e-6", "weight_decay=0.01"],
+                },
+                runtime,
+                "run-1",
+            )
+
+        self.assertEqual(adapted.values["optimizer_args"], ["eps=1e-6", "weight_decay=0.01"])
+        self.assertFalse(any("eps=1e-8" in warning for warning in adapted.warnings))
+
     def test_preflight_rejects_compile_mode_full_with_gradient_checkpointing(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## Summary

- Adds an Anima Fast adapter default of `eps=1e-8` for `optimizer_type=DAdaptAdaGrad` when the user has not provided `eps=`.
- Preserves explicit user `eps` values in `optimizer_args_custom`, so advanced configs remain in control.
- Documents the dadaptation 3.1 default `eps=0.0` crash and the Fast-side default.

## Test plan

- `python -m pytest tests/test_anima_fast_backend.py tests/test_anima_fast_integration_static.py`

Fixes wochenlong/lora-scripts-next#98