### PR TITLE
fix(anima): load ComfyUI-saved checkpoints

### DIFF
--- a/tests/test_anima_checkpoint_key_normalization.py
+++ b/tests/test_anima_checkpoint_key_normalization.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "vendor" / "sd-scripts"))
+
+from library.anima_utils import normalize_anima_checkpoint_key  # noqa: E402
+
+
+class AnimaCheckpointKeyNormalizationTests(unittest.TestCase):
+    def test_accepts_known_save_prefixes(self):
+        expected = "x_embedder.proj.1.weight"
+
+        self.assertEqual(normalize_anima_checkpoint_key(f"net.{expected}"), expected)
+        self.assertEqual(normalize_anima_checkpoint_key(expected), expected)
+        self.assertEqual(normalize_anima_checkpoint_key(f"model.diffusion_model.{expected}"), expected)
+        self.assertEqual(normalize_anima_checkpoint_key(f"diffusion_model.{expected}"), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/sd-scripts/library/anima_utils.py
+++ b/vendor/sd-scripts/library/anima_utils.py
@@ -27,6 +27,14 @@ logger = logging.getLogger(__name__)
 FP8_OPTIMIZATION_TARGET_KEYS = ["blocks", ""]
 # ".embed." excludes Embedding in LLMAdapter
 FP8_OPTIMIZATION_EXCLUDE_KEYS = ["_embedder", "norm", "adaln", "final_layer", ".embed."]
+ANIMA_CHECKPOINT_KEY_PREFIXES = ("net.", "model.diffusion_model.", "diffusion_model.")
+
+
+def normalize_anima_checkpoint_key(key: str) -> str:
+    for prefix in ANIMA_CHECKPOINT_KEY_PREFIXES:
+        if key.startswith(prefix):
+            return key[len(prefix) :]
+    return key
 
 
 def load_anima_model(
@@ -103,7 +111,7 @@ def load_anima_model(
 
     # load model weights with dynamic fp8 optimization and LoRA merging if needed
     logger.info(f"Loading DiT model from {dit_path}, device={loading_device}")
-    rename_hooks = WeightTransformHooks(rename_hook=lambda k: k[len("net.") :] if k.startswith("net.") else k)
+    rename_hooks = WeightTransformHooks(rename_hook=normalize_anima_checkpoint_key)
     sd = load_safetensors_with_lora_and_fp8(
         model_files=dit_path,
         lora_weights_list=lora_weights_list,


### PR DESCRIPTION
## Summary

- Adds Anima checkpoint key normalization for ComfyUI `model.diffusion_model.*` and `diffusion_model.*` prefixes.
- Keeps existing support for official `net.*` checkpoints and bare-key fine-tuned checkpoints.
- Adds a regression test covering all supported Anima DiT key prefix forms.

## Verification

- RED: `<venv>/python -m unittest tests.test_anima_checkpoint_key_normalization` failed before the normalizer existed.
- GREEN: same unittest passes after the fix.
- Smoke: WAI-Anima 1 epoch standard Anima LoRA train now loads `waiANIMA_v10Base10.safetensors` with `unexpected missing keys: 0, unexpected keys: 0` and saves a smoke LoRA checkpoint.

Fixes wochenlong/lora-scripts-next#100