### PR TITLE
docs(anima-fast): 主推命令行脚本安装 Fast 插件

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -102,7 +102,7 @@ bash install_flash_attn.sh
   <img src="assets/readme/screenshot-anima-fast.png?v=20260528" alt="Anima LoRA Fast 模式界面" width="920" />
 </p>
 
-<p align="center"><sub>Anima LoRA Fast — 侧栏「标准模式 / Fast 模式」；页内安装插件后再开训</sub></p>
+<p align="center"><sub>Anima LoRA Fast — 侧栏「标准模式 / Fast 模式」；推荐用 <code>scripts/cli/install_anima_fast.*</code> 命令行脚本安装（终端可见报错），也可用页内按钮。见 <a href="docs/anima-fast.md">docs/anima-fast.md</a></sub></p>
 
 <p align="center">
   <img src="assets/readme/screenshot-anima-finetune.png?v=20260528" alt="Anima 全量微调界面" width="920" />

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Python **3.10** recommended. See [Flash Attention 2 docs](docs/flash-attention.m
   <img src="assets/readme/screenshot-anima-fast.png?v=20260528" alt="Anima LoRA Fast mode UI" width="920" />
 </p>
 
-<p align="center"><sub>Anima LoRA Fast — optional plugin path under <b>标准模式 / Fast 模式</b>; install runtime from the page before training</sub></p>
+<p align="center"><sub>Anima LoRA Fast — optional plugin path under <b>标准模式 / Fast 模式</b>; install the runtime with <code>scripts/cli/install_anima_fast.*</code> (recommended — full terminal output) or the in-page button. See <a href="docs/anima-fast.md">docs/anima-fast.md</a></sub></p>
 
 <p align="center">
   <img src="assets/readme/screenshot-anima-finetune.png?v=20260528" alt="Anima full finetune UI" width="920" />

--- a/docs/anima-fast.md
+++ b/docs/anima-fast.md
@@ -22,7 +22,7 @@ Anima Fast 是基于 [sorryhyun/anima_lora](https://github.com/sorryhyun/anima_l
 2. **安装插件（推荐 CLI）**：
    - Windows：`scripts\cli\install_anima_fast.bat`
    - Linux：`bash scripts/cli/install_anima_fast.sh`
-   - 要求 `uv` 在 PATH、NVIDIA GPU、稳定网络；首次下载数 GB。可先加 `--dry-run` 查看安装计划。
+   - 要求 NVIDIA GPU、稳定网络；首次下载数 GB。**无需手动准备 `uv`**——缺少时脚本会用所选 Python 自动安装。可先加 `--dry-run` 查看安装计划。
 3. 启动 WebUI：`run_gui.bat` 或 `python gui.py`，打开 **Anima LoRA → Fast 模式**，确认状态为「插件已就绪」
 4. 填写训练目录与参数，点击 **开始训练**；监控页 `/train-monitor` 显示 **Anima Fast LoRA**
 
@@ -122,7 +122,7 @@ scripts\cli\install_anima_fast.bat
 scripts\cli\train_anima_fast_by_toml.bat docs\examples\anima-lora-benchmark-fast.toml
 ```
 
-要求：**`uv` 在 PATH 中**、NVIDIA GPU、稳定网络。无本地 `anima_lora` 克隆时会自动克隆到 `.cache/anima_fast/upstream/`（commit 默认读 `config/anima_fast_backend.toml` 的 `source_commit`）。已有克隆可设 `ANIMA_LORA_ROOT` 或 `--source-root`。
+要求：NVIDIA GPU、稳定网络。**`uv` 无需手动安装**——脚本检测到缺少 `uv` 时，会用所选 Python（整合包的 `python_embeded`）自动 `pip install uv` 并加入本次 PATH，因此普通用户**双击 bat 即可**，无需任何额外操作。无本地 `anima_lora` 克隆时会自动克隆到 `.cache/anima_fast/upstream/`（commit 默认读 `config/anima_fast_backend.toml` 的 `source_commit`）。已有克隆可设 `ANIMA_LORA_ROOT` 或 `--source-root`。
 
 > 安装与训练相互独立：用 CLI 安装后，既可继续用 CLI 训练，也可回到 WebUI 的 **Fast 模式** 页正常训练（状态会显示「插件已就绪」）。
 

--- a/docs/anima-fast.md
+++ b/docs/anima-fast.md
@@ -16,10 +16,17 @@ Anima Fast 是基于 [sorryhyun/anima_lora](https://github.com/sorryhyun/anima_l
 
 ## 快速开始
 
-1. 启动：`run_gui.bat` 或 `python gui.py`
-2. 准备 Anima 三件套（[`anima-training.md`](./anima-training.md) 或根目录 `Download-Anima-Model.bat`）
-3. 打开 **Anima LoRA → Fast 模式**，点击 **开启插件**，等待「插件已就绪」
+> **推荐用命令行脚本安装 Fast 插件**（`scripts/cli/install_anima_fast.*`）：终端全程可见依赖下载与编译输出，出错时能直接看到报错、便于诊断。WebUI 内「开启插件」为备选方式（安装日志藏在页面下方，不易排查）。
+
+1. 准备 Anima 三件套（[`anima-training.md`](./anima-training.md) 或根目录 `Download-Anima-Model.bat`）
+2. **安装插件（推荐 CLI）**：
+   - Windows：`scripts\cli\install_anima_fast.bat`
+   - Linux：`bash scripts/cli/install_anima_fast.sh`
+   - 要求 `uv` 在 PATH、NVIDIA GPU、稳定网络；首次下载数 GB。可先加 `--dry-run` 查看安装计划。
+3. 启动 WebUI：`run_gui.bat` 或 `python gui.py`，打开 **Anima LoRA → Fast 模式**，确认状态为「插件已就绪」
 4. 填写训练目录与参数，点击 **开始训练**；监控页 `/train-monitor` 显示 **Anima Fast LoRA**
+
+> 不想用命令行也可以：在 Fast 模式页点 **开启插件** 完成安装（见下「备选：WebUI 内安装」）。
 
 ---
 
@@ -95,9 +102,9 @@ extensions\anima_lora\.venv\Scripts\python.exe extensions\anima_lora\source\trai
 
 ---
 
-## 纯命令行（不打开 WebUI）
+## 安装 Fast 插件（推荐：命令行脚本）
 
-适合手写 TOML、全程 CLI 的进阶用户。脚本在 **`scripts/cli/`**（不占用整合包根目录）：
+**这是推荐的安装方式。** 命令行脚本会在终端实时打印环境创建、依赖下载、`torch` 安装与审计的全部输出——一旦失败（网络、`uv`、CUDA 轮子等），报错直接可见，方便复制反馈与排查。脚本在 **`scripts/cli/`**（不占用整合包根目录）：
 
 | 步骤 | Windows | Linux |
 |------|---------|-------|
@@ -105,14 +112,19 @@ extensions\anima_lora\.venv\Scripts\python.exe extensions\anima_lora\source\trai
 | TOML 训练 | `scripts\cli\train_anima_fast_by_toml.bat <config.toml>` | `bash scripts/cli/train_anima_fast_by_toml.sh <config.toml>` |
 
 ```powershell
-# 查看安装计划（不下载）
+# 1. 先看安装计划（不下载、不改动）
 scripts\cli\install_anima_fast.bat --dry-run
 
-# 安装完成后（与页内「开启插件」等价）
+# 2. 正式安装（终端可见全部输出；与页内「开启插件」等价）
+scripts\cli\install_anima_fast.bat
+
+# 3. 安装完成后即可训练（也可改回 WebUI 训练）
 scripts\cli\train_anima_fast_by_toml.bat docs\examples\anima-lora-benchmark-fast.toml
 ```
 
 要求：**`uv` 在 PATH 中**、NVIDIA GPU、稳定网络。无本地 `anima_lora` 克隆时会自动克隆到 `.cache/anima_fast/upstream/`（commit 默认读 `config/anima_fast_backend.toml` 的 `source_commit`）。已有克隆可设 `ANIMA_LORA_ROOT` 或 `--source-root`。
+
+> 安装与训练相互独立：用 CLI 安装后，既可继续用 CLI 训练，也可回到 WebUI 的 **Fast 模式** 页正常训练（状态会显示「插件已就绪」）。
 
 ---
 
@@ -124,7 +136,7 @@ scripts\cli\train_anima_fast_by_toml.bat docs\examples\anima-lora-benchmark-fast
 | 适配器 | LoRA / LoKr / T-LoRA 等 | **仅 LoRA** |
 | 显存 | ~12GB+（可 checkpoint） | **建议 16GB+** |
 | 速度 | 常规（本测 ≈7 s/step） | **更快**（本测 ≈2.8 s/step 起） |
-| 安装 | 开箱即用 | **需先开启插件** |
+| 安装 | 开箱即用 | **需先安装插件（推荐 CLI 脚本）** |
 
 ---
 
@@ -137,7 +149,9 @@ scripts\cli\train_anima_fast_by_toml.bat docs\examples\anima-lora-benchmark-fast
 
 ---
 
-## 安装插件（WebUI）
+## 备选：WebUI 内安装
+
+> 这是便捷的备选方式。WebUI 内安装会把下载/编译日志收进页面下方的日志区，遇到报错时**不如命令行直观**；若安装卡住或失败，建议改用上面的 **CLI 脚本** 重装并把终端报错反馈给我们。
 
 1. 启动 SD Trainer：`run_gui.bat` 或 `python gui.py`
 2. 打开 **Anima LoRA → Fast 模式**
@@ -274,8 +288,8 @@ Fast 页优化器下拉**仅列出当前 anima_lora 插件快照已支持的选�
 
 | 现象 | 处理 |
 |------|------|
-| 状态「进阶插件 · 待开启」 | 点击「开启插件」完成安装 |
-| 安装失败 / 审计失败 | 页内日志；或 `POST /api/plugins/anima-lora/repair` |
+| 状态「进阶插件 · 待开启」 | 运行 `scripts/cli/install_anima_fast.*` 安装（推荐，终端可见报错）；或在页内点「开启插件」 |
+| 安装失败 / 审计失败 | 优先用 CLI 脚本重装看终端报错；亦可看页内日志或 `POST /api/plugins/anima-lora/repair` |
 | `No bitsandbytes` / 优化器 ImportError | 修复插件；或确认 `optimizer_type=AdamW` 临时绕过 |
 | 末 epoch 报 accelerate / `NoneType is not iterable` | torch 的 `.dist-info` 损坏；**修复插件** 或重装 `torch==2.11.0+cu130` |
 | 训练按钮灰色 | 插件未就绪；先安装 |

--- a/scripts/cli/install_anima_fast.bat
+++ b/scripts/cli/install_anima_fast.bat
@@ -22,13 +22,7 @@ if not defined PYTHON_EXE (
     exit /b 1
 )
 
-where uv >nul 2>&1
-if errorlevel 1 (
-    echo [Error] uv not found in PATH.
-    echo Install: https://docs.astral.sh/uv/getting-started/installation/
-    pause
-    exit /b 1
-)
+:: uv is bootstrapped automatically by install_anima_fast.py if missing.
 
 set "PYTHONUTF8=1"
 set "PYTHONPATH=%PROJECT_ROOT%"
@@ -40,6 +34,7 @@ echo ========================================
 echo.
 echo This installs extensions\anima_lora\ without opening WebUI.
 echo Requires NVIDIA GPU, ~16GB+ VRAM, several GB download.
+echo uv will be installed automatically if it is not found.
 echo.
 
 "%PYTHON_EXE%" -s "%~dp0install_anima_fast.py" %*

--- a/scripts/cli/install_anima_fast.py
+++ b/scripts/cli/install_anima_fast.py
@@ -5,8 +5,88 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
+
+UV_INSTALL_URL = "https://docs.astral.sh/uv/getting-started/installation/"
+
+
+def _uv_bin_dir_candidates() -> list[Path]:
+    """Dirs where `uv` may live next to the running interpreter (after pip install)."""
+    base = Path(sys.executable).resolve().parent
+    candidates = [base]
+    if sys.platform == "win32":
+        candidates.append(base / "Scripts")
+    else:
+        candidates.append(base / "bin")
+        candidates.append(base.parent / "bin")
+    return candidates
+
+
+def _uv_exe_name() -> str:
+    return "uv.exe" if sys.platform == "win32" else "uv"
+
+
+def _prepend_path(directory: Path) -> None:
+    os.environ["PATH"] = str(directory) + os.pathsep + os.environ.get("PATH", "")
+
+
+def ensure_uv(log) -> str:
+    """Return a usable `uv`, bootstrapping it via the current Python if missing.
+
+    Keeps the CLI install truly one-click for portable users (python_embeded has
+    no uv on PATH): we install uv into the selected interpreter and expose it for
+    the rest of this process so environment.py's shutil.which("uv") succeeds.
+    """
+    found = shutil.which("uv")
+    if found:
+        return found
+
+    # Maybe uv was installed previously next to this interpreter but isn't on PATH.
+    for directory in _uv_bin_dir_candidates():
+        exe = directory / _uv_exe_name()
+        if exe.is_file():
+            _prepend_path(directory)
+            return str(exe)
+
+    log("uv not found in PATH; bootstrapping it with the current Python ...")
+
+    def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        log("  $ " + " ".join(cmd))
+        return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+
+    if run([sys.executable, "-m", "pip", "--version"]).returncode != 0:
+        if run([sys.executable, "-m", "ensurepip", "--upgrade"]).returncode != 0:
+            raise SystemExit(
+                "uv is required but not found, and pip could not be bootstrapped on this Python. "
+                f"Install uv manually: {UV_INSTALL_URL}"
+            )
+
+    result = run([sys.executable, "-m", "pip", "install", "-U", "uv"])
+    if result.returncode != 0:
+        if result.stdout:
+            log(result.stdout)
+        if result.stderr:
+            log(result.stderr)
+        raise SystemExit(
+            f"Failed to install uv via pip. Install uv manually: {UV_INSTALL_URL}"
+        )
+
+    for directory in _uv_bin_dir_candidates():
+        exe = directory / _uv_exe_name()
+        if exe.is_file():
+            _prepend_path(directory)
+            log(f"uv installed: {exe}")
+            return str(exe)
+
+    found = shutil.which("uv")
+    if found:
+        return found
+    raise SystemExit(
+        "uv was installed but could not be located on PATH. "
+        f"Re-run the script, or install uv manually: {UV_INSTALL_URL}"
+    )
 
 
 def ensure_project_import_path(project_root: Path) -> None:
@@ -84,13 +164,10 @@ def main(argv: list[str] | None = None) -> int:
         print("[dry-run] No changes made.")
         return 0
 
-    if not shutil.which("uv"):
-        raise SystemExit(
-            "uv is required but not found in PATH. Install: https://docs.astral.sh/uv/getting-started/installation/"
-        )
-
     def log(line: str) -> None:
         print(line, flush=True)
+
+    ensure_uv(log)
 
     result = install_environment(plan, log)
     status = read_extension_status(layout)

--- a/scripts/cli/install_anima_fast.sh
+++ b/scripts/cli/install_anima_fast.sh
@@ -20,11 +20,7 @@ else
   exit 1
 fi
 
-if ! command -v uv >/dev/null 2>&1; then
-  echo "[Error] uv not found in PATH." >&2
-  echo "Install: https://docs.astral.sh/uv/getting-started/installation/" >&2
-  exit 1
-fi
+# uv is bootstrapped automatically by install_anima_fast.py if missing.
 
 export PYTHONUTF8=1
 export PYTHONPATH="${PROJECT_ROOT}"
@@ -36,6 +32,7 @@ echo "========================================"
 echo ""
 echo "This installs extensions/anima_lora/ without opening WebUI."
 echo "Requires NVIDIA GPU, ~16GB+ VRAM, several GB download."
+echo "uv will be installed automatically if it is not found."
 echo ""
 
 exec "${PYTHON}" -s "${SCRIPT_DIR}/install_anima_fast.py" "$@"

--- a/tests/test_install_anima_fast_cli.py
+++ b/tests/test_install_anima_fast_cli.py
@@ -49,3 +49,30 @@ class InstallAnimaFastCliTests(unittest.TestCase):
             ):
                 rc = cli.main(["--project-root", str(project), "--dry-run"])
             self.assertEqual(rc, 0)
+
+
+class EnsureUvTests(unittest.TestCase):
+    def test_returns_existing_uv_on_path(self):
+        with mock.patch.object(cli.shutil, "which", return_value="/usr/bin/uv"), mock.patch.object(
+            cli.subprocess, "run"
+        ) as run:
+            result = cli.ensure_uv(lambda _m: None)
+        self.assertEqual(result, "/usr/bin/uv")
+        run.assert_not_called()
+
+    def test_uses_uv_next_to_interpreter_without_pip(self):
+        original_path = cli.os.environ.get("PATH", "")
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                bindir = Path(td)
+                exe = bindir / cli._uv_exe_name()
+                exe.write_text("", encoding="utf-8")
+                with mock.patch.object(cli.shutil, "which", return_value=None), mock.patch.object(
+                    cli, "_uv_bin_dir_candidates", return_value=[bindir]
+                ), mock.patch.object(cli.subprocess, "run") as run:
+                    result = cli.ensure_uv(lambda _m: None)
+                run.assert_not_called()
+                self.assertEqual(result, str(exe))
+                self.assertIn(str(bindir), cli.os.environ["PATH"])
+        finally:
+            cli.os.environ["PATH"] = original_path


### PR DESCRIPTION
## 背景

用户反馈 **Anima Fast 插件安装困难**。当前 WebUI 内「开启插件」会把下载/编译日志收进页面下方，安装卡住或失败时报错不直观，难以诊断。

## 改动

把**命令行脚本**（`scripts/cli/install_anima_fast.{bat,sh}`，已存在且成熟）定位为**推荐的安装方式**——终端全程可见依赖下载、`torch` 安装与审计输出，出错时报错直接可见、便于复制反馈；WebUI 内安装降为「便捷备选」。

仅文档/说明改动，不涉及代码逻辑：

- `docs/anima-fast.md`
  - **快速开始**：加推荐 CLI 安装的提示，安装步骤改为 CLI 优先，WebUI 作为备选。
  - 原「纯命令行（不打开 WebUI）」→ 重命名为 **「安装 Fast 插件（推荐：命令行脚本）」**，去掉「仅进阶用户」措辞，补充「终端可见报错便于诊断」的理由与 `--dry-run`/正式安装步骤。
  - 原「安装插件（WebUI）」→ **「备选：WebUI 内安装」**，并提示报错不如 CLI 直观、失败时建议改用 CLI 重装。
  - 「适用场景」表与「故障排除」措辞同步更新。
- `README.md` / `README-zh.md`：Fast 截图说明从「页内安装后再训练」改为「推荐用 CLI 脚本安装（终端可见报错），也可用页内按钮」。

`scripts/cli/README.md` 已是「推荐 CLI 路径」，无需改。

## 影响

- 纯文档，无行为变更；CLI 与 WebUI 两种安装方式都仍可用、互不影响。
