### PR TITLE
fix(anima): add LoKr full_matrix stability guardrails (#25)

### DIFF
--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -361,6 +361,30 @@ def _anima_lokr_training(config: dict) -> bool:
     return False
 
 
+def _is_truthy(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _anima_lokr_full_matrix_training(config: dict) -> bool:
+    if not _anima_lokr_training(config):
+        return False
+    if _is_truthy(config.get("full_matrix")):
+        return True
+    for item in config.get("network_args") or []:
+        if not isinstance(item, str) or "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        if key.strip().lower() == "full_matrix" and _is_truthy(value):
+            return True
+    return False
+
+
 def apply_anima_training_defaults(config: dict, model_train_type: str):
     if model_train_type not in ANIMA_TRAIN_TYPES:
         return
@@ -402,6 +426,19 @@ def apply_anima_training_defaults(config: dict, model_train_type: str):
                 f"{config.get('optimizer_type')} ({', '.join(disabled)}). "
                 "This keeps trainable LoRA weights in fp32 to reduce loss=nan risk."
             )
+    elif _anima_lokr_full_matrix_training(config):
+        disabled = []
+        for key in ("full_bf16", "full_fp16"):
+            if config.pop(key, None):
+                disabled.append(key)
+        if _is_invalid_value(config.get("scale_weight_norms")):
+            config["scale_weight_norms"] = 1
+        log.warning(
+            "Anima LoKr full_matrix=true uses conservative stability guardrails: "
+            "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1. "
+            "Disabled full half precision: %s",
+            ", ".join(disabled) if disabled else "none",
+        )
     elif _anima_lokr_training(config):
         # LyCORIS LoKr can hit dtype mismatch under mixed precision when adapter
         # params stay fp32 while activations are bf16/fp16.

--- a/mikazuki/schema/sd3-lora.ts
+++ b/mikazuki/schema/sd3-lora.ts
@@ -79,7 +79,7 @@ Schema.intersect([
                 network_module: Schema.const("lycoris.kohya").default("lycoris.kohya").hidden(),
                 lycoris_algo: Schema.const("lokr").default("lokr").hidden(),
                 lokr_factor: Schema.number().min(-1).default(-1).description("LoKr 分解因子。常用 4~无穷，填写 -1 为无穷"),
-                full_matrix: Schema.boolean().default(false).description("使用全矩阵模式（替代大 dim），开启后 LoKr 使用完整 Kronecker 乘积而非低秩近似"),
+                full_matrix: Schema.boolean().default(false).description("使用全矩阵模式（高风险）。开启后系统会自动启用保守稳定性护栏：可训练权重保持 FP32，并默认 scale_weight_norms=1"),
                 use_cp: Schema.boolean().default(false).description("使用 CP 分解"),
                 use_scalar: Schema.boolean().default(false).description("使用可学习缩放系数"),
                 decompose_both: Schema.boolean().default(false).description("同时分解输入与输出维度"),

--- a/tests/test_anima_training_defaults.py
+++ b/tests/test_anima_training_defaults.py
@@ -33,6 +33,22 @@ class AnimaTrainingDefaultsTests(unittest.TestCase):
 
         self.assertTrue(config.get("full_bf16"))
 
+    def test_anima_lokr_full_matrix_uses_conservative_guardrails(self):
+        config = {
+            "mixed_precision": "bf16",
+            "full_bf16": True,
+            "optimizer_type": "AdamW8bit",
+            "network_module": "lycoris.kohya",
+            "network_args": ["algo=lokr", "full_matrix=True"],
+            "unet_lr": "5e-5",
+            "attn_mode": "torch",
+        }
+
+        apply_anima_training_defaults(config, "anima-lora")
+
+        self.assertNotIn("full_bf16", config)
+        self.assertEqual(config["scale_weight_norms"], 1)
+
     def test_anima_disables_full_bf16_for_came(self):
         config = {
             "mixed_precision": "bf16",


### PR DESCRIPTION
## Summary

Fixes #25. When Anima LoKr training uses `full_matrix=true`, the previous defaults could still enable `full_bf16`/`full_fp16`, which contributed to first-epoch instability.

This ports the conservative guardrail from @MikumikuDAIFans's `origin/anima_lora` work:

- Detect `full_matrix=true` from the top-level flag or `network_args`
- Disable `full_bf16` / `full_fp16` so trainable adapter weights stay in fp32
- Default `scale_weight_norms=1` when unset
- Update the LoKr schema description to mark the mode as high-risk and document the automatic guardrails

## Test plan

- [x] `python -m unittest tests.test_anima_training_defaults -v` (9 tests, including new `test_anima_lokr_full_matrix_uses_conservative_guardrails`)