### PR TITLE
fix(ui): restore legacy tag editor startup

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -21,7 +21,7 @@ parser.add_argument("--disable-tageditor", action="store_true")
 parser.add_argument(
     "--enable-legacy-tageditor",
     action="store_true",
-    help="Start the legacy Gradio Dataset Tag Editor compatibility service.",
+    help="Deprecated compatibility flag. Legacy Gradio Dataset Tag Editor now starts by default.",
 )
 parser.add_argument("--disable-train-monitor", action="store_true")
 parser.add_argument("--disable-auto-mirror", action="store_true")
@@ -124,7 +124,7 @@ def launch():
     log.info("Starting SD-Trainer Mikazuki GUI...")
     log.info(f"Base directory: {base_dir_path()}, Working directory: {os.getcwd()}")
     log.info(f"{platform.system()} Python {platform.python_version()} {sys.executable}")
-    legacy_tageditor_enabled = args.enable_legacy_tageditor and not args.disable_tageditor
+    legacy_tageditor_enabled = not args.disable_tageditor
 
     if not args.skip_prepare_environment:
         prepare_environment(disable_auto_mirror=args.disable_auto_mirror)

--- a/tests/test_dataset_editor_api.py
+++ b/tests/test_dataset_editor_api.py
@@ -443,12 +443,12 @@ def test_embedded_dataset_editor_pager_wraps_before_buttons_overflow():
     assert "justify-content: flex-start;" in pager_breakpoint
 
 
-def test_legacy_gradio_tageditor_is_opt_in():
+def test_legacy_gradio_tageditor_starts_by_default_for_existing_users():
     gui = (ROOT / "gui.py").read_text(encoding="utf-8")
 
     assert "--enable-legacy-tageditor" in gui
-    assert "legacy_tageditor_enabled = args.enable_legacy_tageditor" in gui
-    assert "Using native dataset editor at /dataset-editor.html" in gui
+    assert "legacy_tageditor_enabled = not args.disable_tageditor" in gui
+    assert "run_tag_editor(tageditor_port)" in gui
 
 
 def test_dataset_editor_frontend_exposes_edit_efficiency_controls():


### PR DESCRIPTION
# Draft PR - Issue #121

## Title

`fix: restore tag editor entrypoints and locale persistence`

## Branch

`pr/issue-121-tag-editor`

## Base

Recommended: `main` unless maintainers request `dev`.

## Related Issue

`Refs #121`

## Body

```md
## Summary

- Restore/keep the classic tag editor entrypoint and proxy path.
- Preserve native dataset editor API/static behavior.
- Keep locale selection persistent across reloads and compatible with legacy session state.
- Add dataset editor/API and locale persistence regression coverage.

## Validation

- `python -m pytest tests/test_dataset_editor_api.py -q`

## Boundaries

- This PR focuses on tag editor access and locale persistence.
- It does not close the issue until maintainers confirm the combined classic/native editor behavior in the target release branch.

Refs #121
```

## Candidate Files

- Root startup/GUI files from clean repo if needed.
- Tag editor proxy/static entrypoint files.
- `tests/test_dataset_editor_api.py`

## Notes For Split

The migrated project currently lacks root-level files and contains `mikazuki/dataset-tag-editor` with nested `.git` metadata. Before PR creation, confirm whether this editor should remain a submodule, a vendored directory, or a smaller entrypoint fix.

