### PR TITLE
fix: stabilize Anima Fast preview runtime defaults

### DIFF
--- a/mikazuki/anima_fast_backend/adapter.py
+++ b/mikazuki/anima_fast_backend/adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from pathlib import Path
 import re
 from typing import Any
@@ -81,6 +82,11 @@ FAST_SUPPORTED_OPTIMIZERS = {
     "Prodigy",
     "pytorch_optimizer.CAME",
 }
+
+FAST_CACHE_PAIRS = (
+    ("cache_latents", "cache_latents_to_disk"),
+    ("cache_text_encoder_outputs", "cache_text_encoder_outputs_to_disk"),
+)
 
 
 @dataclass
@@ -312,9 +318,17 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
                 f"static_token_count 已按 resolution 自动提高到 {tokens}；"
                 "高分辨率 Fast compile 会显著增加显存占用"
             )
-    cache_keys = ("cache_latents", "cache_text_encoder_outputs")
+    for cache_key, disk_key in FAST_CACHE_PAIRS:
+        values.setdefault(cache_key, False)
+        if not truthy(values.get(cache_key)):
+            values[disk_key] = False
+        else:
+            values.setdefault(disk_key, True)
+    values.setdefault("skip_cache_check", False)
+
+    cache_keys = tuple(cache_key for cache_key, _disk_key in FAST_CACHE_PAIRS)
     if truthy(values.get("skip_cache_check")) and any(truthy(values.get(key)) for key in cache_keys):
-        for key in (*cache_keys, "skip_cache_check"):
+        for key in (*cache_keys, *(disk_key for _cache_key, disk_key in FAST_CACHE_PAIRS), "skip_cache_check"):
             values[key] = False
         warnings.append(
             "cache_latents/cache_text_encoder_outputs 不能与 skip_cache_check 同时开启；"
@@ -325,6 +339,8 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
         values["compile_mode"] = "blocks"
         warnings.append("compile_mode=full 与 gradient_checkpointing 不兼容，已自动改为 blocks")
     values.setdefault("dynamo_backend", "inductor")
+    values.setdefault("log_prefix", "af_")
+    values.setdefault("log_tracker_name", "tb")
     if is_empty(values.get("attn_mode")):
         values["attn_mode"] = "torch"
         warnings.append("attn_mode 留空时使用 torch 保底；如需 flash 请先确认插件环境已安装 flash-attn")
@@ -368,3 +384,23 @@ def toml_scalar(value: Any) -> str:
 
 def dump_flat_toml(values: dict[str, Any]) -> str:
     return "".join(f"{key} = {toml_scalar(value)}\n" for key, value in values.items())
+
+
+def ensure_fast_run_log_dirs(values: dict[str, Any], now: datetime | None = None) -> list[Path]:
+    logging_dir = values.get("logging_dir")
+    if is_empty(logging_dir):
+        return []
+    root = Path(str(logging_dir))
+    root.mkdir(parents=True, exist_ok=True)
+
+    created = [root]
+    current = now or datetime.now()
+    parts = [p for p in (values.get("method"), values.get("preset", "default")) if not is_empty(p)]
+    log_prefix = ("_".join(str(p) for p in parts) + "_") if parts else ""
+    tracker_name = str(values.get("log_tracker_name") or "network_train")
+    for offset in range(3):
+        run_dir = root / f"{log_prefix}{(current + timedelta(minutes=offset)).strftime('%Y%m%d-%H%M')}"
+        tracker_dir = run_dir / tracker_name
+        tracker_dir.mkdir(parents=True, exist_ok=True)
+        created.append(tracker_dir)
+    return created

--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -34,7 +34,12 @@ from fastapi.responses import StreamingResponse
 import mikazuki.process as process
 from mikazuki import launch_utils
 from mikazuki.anima_fast_backend import TRAIN_TYPE as ANIMA_FAST_TRAIN_TYPE
-from mikazuki.anima_fast_backend.adapter import AdapterError, adapt_config, dump_flat_toml
+from mikazuki.anima_fast_backend.adapter import (
+    AdapterError,
+    adapt_config,
+    dump_flat_toml,
+    ensure_fast_run_log_dirs,
+)
 from mikazuki.anima_fast_backend.extension_state import (
     STATE_INSTALLED_UNVERIFIED,
     STATE_READY,
@@ -505,6 +510,7 @@ def _write_anima_fast_toml(config: dict, timestamp: str, autosave_dir: str) -> t
 
 def _write_adapted_anima_fast_toml(values: dict, warnings: list[str], run_id: str, autosave_dir: str) -> tuple[Path, dict, list[str]]:
     toml_file = Path(autosave_dir) / f"{run_id}.toml"
+    ensure_fast_run_log_dirs(values)
     toml_file.write_text(dump_flat_toml(values), encoding="utf-8")
     return toml_file, values, warnings
 

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -11,6 +11,7 @@ from mikazuki.anima_fast_backend.adapter import (
     adapt_config,
     dataset_cache_slug,
     dump_flat_toml,
+    ensure_fast_run_log_dirs,
 )
 from mikazuki.anima_fast_backend.extension_state import (
     STATE_INSTALLED_UNVERIFIED,
@@ -249,6 +250,50 @@ class AdapterTests(unittest.TestCase):
         self.assertNotIn("unsloth_offload_checkpointing", adapted.values)
         self.assertTrue(any("blocks_to_swap" in warning for warning in adapted.warnings))
 
+    def test_adapt_config_forces_live_encoding_cache_overrides(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            adapted = adapt_config({
+                "lora_type": "lora",
+                "cache_latents": False,
+                "cache_latents_to_disk": True,
+                "cache_text_encoder_outputs": False,
+                "cache_text_encoder_outputs_to_disk": True,
+            }, runtime, "run-1")
+
+        self.assertFalse(adapted.values["cache_latents"])
+        self.assertFalse(adapted.values["cache_latents_to_disk"])
+        self.assertFalse(adapted.values["cache_text_encoder_outputs"])
+        self.assertFalse(adapted.values["cache_text_encoder_outputs_to_disk"])
+        toml_text = dump_flat_toml(adapted.values)
+        self.assertIn("cache_latents_to_disk = false", toml_text)
+        self.assertIn("cache_text_encoder_outputs_to_disk = false", toml_text)
+
+    def test_adapt_config_uses_short_fast_log_defaults(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            adapted = adapt_config({
+                "lora_type": "lora",
+            }, runtime, "run-1")
+
+        self.assertEqual(adapted.values["log_prefix"], "af_")
+        self.assertEqual(adapted.values["log_tracker_name"], "tb")
+
+    def test_ensure_fast_run_log_dirs_creates_tracker_dirs(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            values = {
+                "logging_dir": str(root / "logs" / "anima_fast"),
+                "method": "lora",
+                "log_tracker_name": "network_train",
+            }
+
+            created = ensure_fast_run_log_dirs(values, now=None)
+
+            self.assertTrue((root / "logs" / "anima_fast").is_dir())
+            self.assertGreaterEqual(len(created), 4)
+            self.assertTrue(any(path.name == "network_train" for path in created))
+
     def test_adapt_config_disables_cache_when_skip_cache_check_is_combined(self):
         with tempfile.TemporaryDirectory() as td:
             runtime = make_runtime(Path(td))
@@ -260,7 +305,9 @@ class AdapterTests(unittest.TestCase):
             }, runtime, "run-1")
 
         self.assertFalse(adapted.values["cache_latents"])
+        self.assertFalse(adapted.values["cache_latents_to_disk"])
         self.assertFalse(adapted.values["cache_text_encoder_outputs"])
+        self.assertFalse(adapted.values["cache_text_encoder_outputs_to_disk"])
         self.assertFalse(adapted.values["skip_cache_check"])
         self.assertTrue(any("skip_cache_check" in warning for warning in adapted.warnings))
 


### PR DESCRIPTION
# Draft PR - Issue #126

## Title

`fix: stabilize Anima Fast preview runtime defaults`

## Branch

`pr/issue-126-fast-preview-runtime`

## Base

Recommended: `main` unless maintainers request `dev`.

## Related Issue

`Refs #126`

## Body

```md
## Summary

- Normalize Anima Fast cache and cache-to-disk pairs.
- Auto-disable conflicting cache flags when `skip_cache_check` is enabled.
- Use shorter, stable Fast log defaults.
- Pre-create Fast log tracker directories before writing the adapted TOML.
- Add Fast adapter/cache/log regression coverage.

## Validation

- `python -m pytest tests/test_anima_fast_backend.py tests/test_anima_fast_task_metadata.py tests/test_anima_fast_preview.py tests/test_anima_fast_plugin_api.py -q`

## Boundaries

- This PR addresses Fast runtime defaults that can prevent preview/log output from appearing.
- Longer Fast training matrices remain separate validation from this focused fix.

Refs #126
```

## Candidate Files

- `mikazuki/anima_fast_backend/adapter.py`
- `mikazuki/app/api.py`
- `tests/test_anima_fast_backend.py`
- `tests/test_anima_fast_task_metadata.py`
- Fast preview/plugin tests as needed.

## Notes For Split

Keep cache/log directory behavior in this PR. Avoid #125 standard task metadata and #127 Anima LoKr guardrails unless an import or shared function requires minimal movement.

