### PR TITLE
fix: return structured standard training task logs

### DIFF
--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -113,6 +113,13 @@ trainer_mapping = {
 }
 
 
+def _missing_standard_train_field(field: str, label: str) -> APIResponseFail:
+    return APIResponseFail(
+        message=f"缺少 {label} ({field})，无法启动训练。请检查训练参数后重试。",
+        data={"field": field},
+    )
+
+
 def _normalize_kv_arg_list(values) -> list[str]:
     """Normalize key=value style arg list from UI payload."""
     if not isinstance(values, list):
@@ -612,16 +619,32 @@ async def create_toml_file(request: Request):
             log.error(f"Anima Fast launch failed: {exc}")
             return APIResponseFail(message=f"Anima Fast launch failed: {exc}")
 
-    suggest_cpu_threads = 8 if len(train_utils.get_total_images(config["train_data_dir"], limit=200)) >= 200 else 2
+    if model_train_type not in trainer_mapping:
+        return APIResponseFail(
+            message=f"不支持的训练类型: {model_train_type}",
+            data={"model_train_type": model_train_type},
+        )
+
+    train_data_dir = str(config.get("train_data_dir") or "").strip()
+    if not train_data_dir:
+        return _missing_standard_train_field("train_data_dir", "训练数据集路径")
+    config["train_data_dir"] = train_data_dir
+
+    pretrained_model = str(config.get("pretrained_model_name_or_path") or "").strip()
+    if not pretrained_model:
+        return _missing_standard_train_field("pretrained_model_name_or_path", "底模路径")
+    config["pretrained_model_name_or_path"] = pretrained_model
+
+    suggest_cpu_threads = 8 if len(train_utils.get_total_images(train_data_dir, limit=200)) >= 200 else 2
     trainer_file = trainer_mapping[model_train_type]
     apply_sdxl_prediction_type(config, model_train_type)
     apply_anima_training_defaults(config, model_train_type)
 
     if model_train_type != "sdxl-finetune":
-        if not train_utils.validate_data_dir(config["train_data_dir"]):
+        if not train_utils.validate_data_dir(train_data_dir):
             return APIResponseFail(message="训练数据集路径不存在或没有图片，请检查目录。")
 
-    validated, message = train_utils.validate_model(config["pretrained_model_name_or_path"], model_train_type)
+    validated, message = train_utils.validate_model(pretrained_model, model_train_type)
     if not validated:
         return APIResponseFail(message=message)
 

--- a/mikazuki/process.py
+++ b/mikazuki/process.py
@@ -154,12 +154,14 @@ def _announce_train_log(task_id: str, urls: dict) -> None:
 def run_train(toml_path: str,
               trainer_file: str = "./scripts/train_network.py",
               gpu_ids: Optional[list] = None,
-              cpu_threads: Optional[int] = 2):
+              cpu_threads: Optional[int] = 2,
+              metadata: Optional[dict] = None):
     log.info(f"Training started with config file / 训练开始，使用配置文件: {toml_path}")
+    cpu_threads = cpu_threads or 2
     args, customize_env, mixed_precision = build_accelerate_train_command(
         trainer_file=trainer_file,
         toml_path=toml_path,
-        cpu_threads=cpu_threads or 2,
+        cpu_threads=cpu_threads,
         gpu_ids=gpu_ids,
     )
 
@@ -181,8 +183,24 @@ def run_train(toml_path: str,
     if gpu_ids:
         log.info(f"Using GPU(s) / 使用 GPU: {gpu_ids}")
 
-    if not (task := tm.create_task(args, customize_env)):
-        return APIResponse(status="error", message="Failed to create task / 无法创建训练任务")
+    task_metadata = {
+        "backend": "standard",
+        "config_path": str(Path(toml_path).resolve()),
+        "trainer_file": trainer_file,
+        "cwd": str(Path.cwd()),
+        "mixed_precision": mixed_precision,
+        "cpu_threads": cpu_threads,
+        "gpu_ids": list(gpu_ids or []),
+        "command": [str(part) for part in args],
+    }
+    task_metadata.update(metadata or {})
+
+    if not (task := tm.create_task(args, customize_env, metadata=task_metadata)):
+        return APIResponse(
+            status="error",
+            message="Failed to create task / 无法创建训练任务",
+            data=task_metadata,
+        )
 
     urls = build_train_log_urls(task.task_id)
     _announce_train_log(task.task_id, urls)
@@ -213,6 +231,9 @@ def run_train(toml_path: str,
             # Full clickable URLs (new in this release).
             "train_log_url": urls["viewer"],
             "train_log_stream_url": urls["stream"],
+            "metadata": task_metadata,
+            "config_path": task_metadata["config_path"],
+            "trainer_file": trainer_file,
         },
     )
 

--- a/mikazuki/tasks.py
+++ b/mikazuki/tasks.py
@@ -13,6 +13,8 @@ import psutil
 from mikazuki.log import log
 from mikazuki.train_log_hub import hub
 
+_FAILURE_LOG_TAIL_LINES = 80
+
 try:
     import msvcrt
     import _winapi
@@ -51,6 +53,7 @@ class Task:
         self.cwd = cwd
         self.returncode = None
         self.log_file = self.metadata.get("log_file")
+        self._stdout_thread = None
 
     def _append_disk_log(self, text: str):
         if not self.log_file:
@@ -73,13 +76,29 @@ class Task:
 
     def finish_log_only(self, returncode=0, error=None):
         self.returncode = returncode
-        self.metadata["returncode"] = returncode
         if error:
             self.metadata["error"] = str(error)
             self._append_disk_log(f"[error] {error}")
         self.status = TaskStatus.FINISHED if returncode == 0 else TaskStatus.FAILED
         self._append_disk_log(f"[task finished] returncode={returncode}")
         hub.mark_done(self.task_id)
+        self._record_completion(returncode)
+
+    def _join_stdout_pump(self):
+        thread = self._stdout_thread
+        if thread and thread.is_alive():
+            thread.join(timeout=2)
+
+    def _record_completion(self, returncode):
+        self.metadata["returncode"] = returncode
+        if returncode == 0:
+            self.metadata.pop("last_log_lines", None)
+            if self.metadata.get("error") == "Training process exited with code 0":
+                self.metadata.pop("error", None)
+            return
+        message = f"Training process exited with code {returncode}"
+        self.metadata.setdefault("error", message)
+        self.metadata["last_log_lines"] = hub.tail(self.task_id, _FAILURE_LOG_TAIL_LINES)
 
     def communicate(self, input=None, timeout=None):
         try:
@@ -96,18 +115,19 @@ class Task:
             raise
         retcode = self.process.poll()
         self.returncode = retcode
-        self.metadata["returncode"] = retcode
         self.status = TaskStatus.FINISHED if retcode == 0 else TaskStatus.FAILED
         self._append_disk_log(f"[task communicate finished] returncode={retcode}")
+        self._record_completion(retcode)
         return CompletedProcess(self.process.args, retcode, stdout, stderr)
 
     def wait(self):
         retcode = self.process.wait()
+        self._join_stdout_pump()
         self.returncode = retcode
-        self.metadata["returncode"] = retcode
         if self.status != TaskStatus.TERMINATED:
             self.status = TaskStatus.FINISHED if retcode == 0 else TaskStatus.FAILED
         self._append_disk_log(f"[task wait finished] returncode={retcode}")
+        self._record_completion(retcode)
 
     def _stdout_pump(self):
         """Drain child stdout into TrainLogHub AND echo to parent console."""
@@ -166,7 +186,8 @@ class Task:
             self.metadata["returncode"] = -1
             self.metadata["error"] = str(e)
             raise
-        threading.Thread(target=self._stdout_pump, daemon=True).start()
+        self._stdout_thread = threading.Thread(target=self._stdout_pump, daemon=True)
+        self._stdout_thread.start()
 
     def terminate(self):
         try:

--- a/mikazuki/train_log_hub.py
+++ b/mikazuki/train_log_hub.py
@@ -65,5 +65,14 @@ class TrainLogHub:
         total = len(lst)
         return lst[start_idx:], total, done
 
+    def tail(self, task_id: str, limit: int = 80) -> List[str]:
+        """Return the most recent sanitized log lines for diagnostics."""
+        limit = max(1, min(int(limit or 1), _MAX_LINES))
+        with self._lock:
+            dq = self._lines.get(task_id)
+            if dq is None:
+                return []
+            return list(dq)[-limit:]
+
 
 hub = TrainLogHub()

--- a/tests/test_process_train_log_url.py
+++ b/tests/test_process_train_log_url.py
@@ -182,5 +182,82 @@ class TruthyEnvTests(unittest.TestCase):
                     self.assertFalse(process._truthy_env("MIKAZUKI_TEST_FLAG"))
 
 
+class RunTrainMetadataTests(unittest.TestCase):
+    def test_run_train_returns_metadata_for_observability(self):
+        task = mock.MagicMock()
+        task.task_id = "task-meta"
+
+        with mock.patch.object(process.tm, "create_task", return_value=task) as create_task, \
+                mock.patch.object(process, "asyncio") as asyncio_mock, \
+                mock.patch.object(process, "_announce_train_log"), \
+                mock.patch.object(process, "build_train_log_urls", return_value={
+                    "base": "http://127.0.0.1:28000",
+                    "viewer": "http://127.0.0.1:28000/train-log?task_id=task-meta",
+                    "stream": "http://127.0.0.1:28000/api/train/log/stream/task-meta",
+                }), \
+                mock.patch.object(process, "read_mixed_precision_from_train_toml", return_value="bf16"):
+            asyncio_mock.to_thread.return_value = object()
+            response = process.run_train(
+                "config/autosave/test.toml",
+                "./scripts/stable/train_network.py",
+                gpu_ids=["0"],
+                cpu_threads=4,
+            )
+
+        self.assertEqual(response.status, "success")
+        create_task.assert_called_once()
+        metadata = create_task.call_args.kwargs["metadata"]
+        self.assertEqual(metadata["backend"], "standard")
+        self.assertEqual(metadata["trainer_file"], "./scripts/stable/train_network.py")
+        self.assertEqual(metadata["mixed_precision"], "bf16")
+        self.assertEqual(metadata["cpu_threads"], 4)
+        self.assertEqual(metadata["gpu_ids"], ["0"])
+        self.assertIn("command", metadata)
+        self.assertEqual(response.data["metadata"], metadata)
+        self.assertEqual(response.data["config_path"], metadata["config_path"])
+        self.assertEqual(response.data["trainer_file"], "./scripts/stable/train_network.py")
+
+    def test_run_train_preserves_extra_metadata_warnings(self):
+        task = mock.MagicMock()
+        task.task_id = "task-warning"
+
+        with mock.patch.object(process.tm, "create_task", return_value=task) as create_task, \
+                mock.patch.object(process, "asyncio") as asyncio_mock, \
+                mock.patch.object(process, "_announce_train_log"), \
+                mock.patch.object(process, "build_train_log_urls", return_value={
+                    "base": "http://127.0.0.1:28000",
+                    "viewer": "http://127.0.0.1:28000/train-log?task_id=task-warning",
+                    "stream": "http://127.0.0.1:28000/api/train/log/stream/task-warning",
+                }), \
+                mock.patch.object(process, "read_mixed_precision_from_train_toml", return_value="bf16"):
+            asyncio_mock.to_thread.return_value = object()
+            response = process.run_train(
+                "config/autosave/test.toml",
+                "./scripts/dev/anima_train_network.py",
+                cpu_threads=2,
+                metadata={"warnings": ["guardrail active"]},
+            )
+
+        metadata = create_task.call_args.kwargs["metadata"]
+        self.assertEqual(response.status, "success")
+        self.assertEqual(metadata["warnings"], ["guardrail active"])
+        self.assertEqual(response.data["metadata"]["warnings"], ["guardrail active"])
+
+    def test_run_train_create_task_failure_returns_diagnostic_data(self):
+        with mock.patch.object(process.tm, "create_task", return_value=None), \
+                mock.patch.object(process, "read_mixed_precision_from_train_toml", return_value=None):
+            response = process.run_train(
+                "config/autosave/test.toml",
+                "./scripts/stable/train_network.py",
+                gpu_ids=None,
+                cpu_threads=2,
+            )
+
+        self.assertEqual(response.status, "error")
+        self.assertIn("trainer_file", response.data)
+        self.assertIn("config_path", response.data)
+        self.assertEqual(response.data["backend"], "standard")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_standard_run_api.py
+++ b/tests/test_standard_run_api.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from starlette.requests import Request
+
+stub_interrogator = types.ModuleType("mikazuki.tagger.interrogator")
+stub_interrogator.available_interrogators = {}
+stub_jobs = types.ModuleType("mikazuki.tagger.jobs")
+stub_jobs.run_interrogate_job = lambda *args, **kwargs: None
+stub_jobs.run_prefetch_job = lambda *args, **kwargs: None
+stub_progress = types.ModuleType("mikazuki.tagger.progress")
+stub_progress.tagger_progress = types.SimpleNamespace(
+    get=lambda: {},
+    request_cancel=lambda: False,
+    is_busy=lambda: False,
+    reset_idle=lambda message=None: None,
+)
+sys.modules["mikazuki.tagger.interrogator"] = stub_interrogator
+sys.modules["mikazuki.tagger.jobs"] = stub_jobs
+sys.modules["mikazuki.tagger.progress"] = stub_progress
+
+from mikazuki.app import api
+
+
+def make_request(payload: dict) -> Request:
+    body = json.dumps(payload).encode("utf-8")
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request({"type": "http", "method": "POST", "path": "/api/run", "headers": []}, receive)
+
+
+class StandardRunApiTests(unittest.TestCase):
+    def test_run_rejects_unknown_standard_train_type_without_500(self):
+        response = asyncio.run(api.create_toml_file(make_request({"model_train_type": "unknown-lora"})))
+
+        self.assertEqual(response.status, "fail")
+        self.assertIn("不支持的训练类型", response.message)
+        self.assertEqual(response.data["model_train_type"], "unknown-lora")
+
+    def test_run_rejects_missing_train_data_dir_without_connect_error(self):
+        response = asyncio.run(api.create_toml_file(make_request({
+            "model_train_type": "sd-lora",
+            "pretrained_model_name_or_path": "runwayml/stable-diffusion-v1-5",
+        })))
+
+        self.assertEqual(response.status, "fail")
+        self.assertEqual(response.data["field"], "train_data_dir")
+        self.assertIn("训练数据集路径", response.message)
+
+    def test_run_rejects_missing_model_path_without_connect_error(self):
+        response = asyncio.run(api.create_toml_file(make_request({
+            "model_train_type": "sd-lora",
+            "train_data_dir": "E:/OpenSourceTeamWork/not-used",
+        })))
+
+        self.assertEqual(response.status, "fail")
+        self.assertEqual(response.data["field"], "pretrained_model_name_or_path")
+        self.assertIn("底模路径", response.message)
+
+    def test_run_starts_standard_lora_with_task_metadata_response(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            data_dir = root / "dataset"
+            (data_dir / "1_class").mkdir(parents=True)
+            model_dir = root / "model"
+            model_dir.mkdir()
+            (model_dir / "model_index.json").write_text("{}", encoding="utf-8")
+
+            payload = {
+                "model_train_type": "sd-lora",
+                "train_data_dir": str(data_dir),
+                "pretrained_model_name_or_path": str(model_dir),
+                "output_dir": str(root / "output"),
+                "output_name": "unit-standard-lora",
+                "enable_preview": False,
+            }
+            fake_response = api.APIResponseSuccess(
+                message="Training started",
+                data={
+                    "task_id": "task-standard",
+                    "train_log_url": "http://127.0.0.1:28000/train-log?task_id=task-standard",
+                    "metadata": {"backend": "standard", "trainer_file": "./scripts/stable/train_network.py"},
+                },
+            )
+
+            with mock.patch.object(api.os, "getcwd", return_value=str(root)), \
+                    mock.patch.object(api.process, "run_train", return_value=fake_response) as run_train:
+                response = asyncio.run(api.create_toml_file(make_request(payload)))
+
+            self.assertEqual(response.status, "success")
+            self.assertEqual(response.data["task_id"], "task-standard")
+            self.assertIn("train_log_url", response.data)
+            run_train.assert_called_once()
+            toml_path, trainer_file, _gpu_ids, cpu_threads = run_train.call_args.args
+            self.assertTrue(Path(toml_path).is_file())
+            self.assertEqual(trainer_file, "./scripts/stable/train_network.py")
+            self.assertEqual(cpu_threads, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_train_log_hub.py
+++ b/tests/test_train_log_hub.py
@@ -32,6 +32,17 @@ class TrainLogHubAnsiTests(unittest.TestCase):
         self.assertEqual(total, 2)
         self.assertFalse(done)
 
+    def test_tail_returns_recent_sanitized_lines(self):
+        hub = TrainLogHub()
+        hub.start_task("task-tail")
+
+        hub.append_line("task-tail", "\x1b[31mfirst\x1b[0m\n")
+        hub.append_line("task-tail", "second\n")
+        hub.append_line("task-tail", "third\n")
+
+        self.assertEqual(hub.tail("task-tail", 2), ["second", "third"])
+        self.assertEqual(hub.tail("missing", 2), [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Draft PR - Issue #125

## Title

`fix: return structured standard training task logs`

## Branch

`pr/issue-125-standard-run-logging`

## Base

Recommended: `main` unless maintainers request `dev`.

## Related Issue

`Refs #125`

## Body

```md
## Summary

- Validate standard training type and required fields before launching.
- Return structured failure responses for missing dataset/model fields.
- Include task id, train log URLs, stream URL, config path, trainer file, and runtime metadata in standard training responses.
- Preserve task returncode, failure error, and bounded log tail for diagnostics.

## Validation

- `python -m pytest tests/test_standard_run_api.py tests/test_process_train_log_url.py tests/test_train_log_hub.py tests/test_train_monitor_status.py -q`

## Boundaries

- This PR improves standard training launch diagnostics and log connectivity.
- It does not imply every model family has been fully trained end-to-end in this branch.

Refs #125
```

## Candidate Files

- `mikazuki/app/api.py`
- `mikazuki/process.py`
- `mikazuki/tasks.py`
- `mikazuki/train_log_hub.py`
- `tests/test_standard_run_api.py`
- `tests/test_process_train_log_url.py`
- `tests/test_train_log_hub.py`
- `tests/test_train_monitor_status.py`

## Notes For Split

Keep standard training validation/logging changes here. Avoid preview gate logic except where necessary for unchanged API imports.

