### PR TITLE
fix: harden Anima LoKr dtype and LyCORIS defaults

### DIFF
--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -113,6 +113,12 @@ trainer_mapping = {
 }
 
 
+def _add_training_warning(config: dict, message: str) -> None:
+    warnings = config.setdefault("_training_warnings", [])
+    if isinstance(warnings, list) and message not in warnings:
+        warnings.append(message)
+
+
 def _normalize_kv_arg_list(values) -> list[str]:
     """Normalize key=value style arg list from UI payload."""
     if not isinstance(values, list):
@@ -412,6 +418,11 @@ def apply_anima_training_defaults(config: dict, model_train_type: str):
     if optimizer_type in ANIMA_FULL_PRECISION_UNSAFE_OPTIMIZERS:
         if config.get("mixed_precision") == "fp16" and _cuda_bf16_supported():
             config["mixed_precision"] = "bf16"
+            _add_training_warning(
+                config,
+                "Changed Anima mixed_precision from fp16 to bf16 for optimizer "
+                f"{config.get('optimizer_type')}. fp16 is more likely to produce loss=nan.",
+            )
             log.warning(
                 "Changed Anima mixed_precision from fp16 to bf16 for optimizer "
                 f"{config.get('optimizer_type')}. fp16 is more likely to produce loss=nan."
@@ -422,11 +433,34 @@ def apply_anima_training_defaults(config: dict, model_train_type: str):
             if config.pop(key, None):
                 disabled.append(key)
         if disabled:
+            _add_training_warning(
+                config,
+                "Disabled Anima full half-precision training for optimizer "
+                f"{config.get('optimizer_type')} ({', '.join(disabled)}). "
+                "This keeps trainable LoRA weights in fp32 to reduce loss=nan risk.",
+            )
             log.warning(
                 "Disabled Anima full half-precision training for optimizer "
                 f"{config.get('optimizer_type')} ({', '.join(disabled)}). "
                 "This keeps trainable LoRA weights in fp32 to reduce loss=nan risk."
             )
+        if _anima_lokr_full_matrix_training(config):
+            had_scale_guardrail = not _is_invalid_value(config.get("scale_weight_norms"))
+            if _is_invalid_value(config.get("scale_weight_norms")):
+                config["scale_weight_norms"] = 1
+            if disabled or not had_scale_guardrail:
+                _add_training_warning(
+                    config,
+                    "Anima LoKr full_matrix=true uses conservative stability guardrails: "
+                    "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1. "
+                    f"Disabled full half precision: {', '.join(disabled) if disabled else 'none'}",
+                )
+                log.warning(
+                    "Anima LoKr full_matrix=true uses conservative stability guardrails: "
+                    "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1. "
+                    "Disabled full half precision: %s",
+                    ", ".join(disabled) if disabled else "none",
+                )
     elif _anima_lokr_full_matrix_training(config):
         disabled = []
         for key in ("full_bf16", "full_fp16"):
@@ -434,6 +468,12 @@ def apply_anima_training_defaults(config: dict, model_train_type: str):
                 disabled.append(key)
         if _is_invalid_value(config.get("scale_weight_norms")):
             config["scale_weight_norms"] = 1
+        _add_training_warning(
+            config,
+            "Anima LoKr full_matrix=true uses conservative stability guardrails: "
+            "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1. "
+            f"Disabled full half precision: {', '.join(disabled) if disabled else 'none'}",
+        )
         log.warning(
             "Anima LoKr full_matrix=true uses conservative stability guardrails: "
             "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1. "
@@ -447,6 +487,11 @@ def apply_anima_training_defaults(config: dict, model_train_type: str):
         full_key = "full_bf16" if mixed == "bf16" else "full_fp16" if mixed == "fp16" else None
         if full_key and not config.get(full_key):
             config[full_key] = True
+            _add_training_warning(
+                config,
+                f"Enabled {full_key} for Anima LoKr mixed_precision={mixed} to keep "
+                "adapter and activation dtypes aligned.",
+            )
             log.info(
                 "Enabled %s for Anima LoKr mixed_precision=%s to keep adapter and "
                 "activation dtypes aligned.",

--- a/tests/test_anima_training_defaults.py
+++ b/tests/test_anima_training_defaults.py
@@ -32,6 +32,7 @@ class AnimaTrainingDefaultsTests(unittest.TestCase):
         apply_anima_training_defaults(config, "anima-lora")
 
         self.assertTrue(config.get("full_bf16"))
+        self.assertIn("Enabled full_bf16 for Anima LoKr", config["_training_warnings"][0])
 
     def test_anima_lokr_full_matrix_uses_conservative_guardrails(self):
         config = {
@@ -48,6 +49,7 @@ class AnimaTrainingDefaultsTests(unittest.TestCase):
 
         self.assertNotIn("full_bf16", config)
         self.assertEqual(config["scale_weight_norms"], 1)
+        self.assertIn("full_matrix=true", config["_training_warnings"][0])
 
     def test_anima_disables_full_bf16_for_came(self):
         config = {
@@ -62,6 +64,28 @@ class AnimaTrainingDefaultsTests(unittest.TestCase):
 
         self.assertNotIn("full_bf16", config)
         self.assertEqual(config["unet_lr"], 2e-5)
+        self.assertIn("pytorch_optimizer.CAME", config["_training_warnings"][0])
+
+    def test_anima_came_lokr_full_matrix_keeps_scale_weight_guardrail(self):
+        config = {
+            "mixed_precision": "fp16",
+            "full_fp16": True,
+            "optimizer_type": "pytorch_optimizer.CAME",
+            "network_module": "lycoris.kohya",
+            "network_args": ["algo=lokr", "full_matrix=True"],
+            "unet_lr": "2e-5",
+            "attn_mode": "torch",
+        }
+
+        with mock.patch("mikazuki.app.api._cuda_bf16_supported", return_value=True):
+            apply_anima_training_defaults(config, "anima-lora")
+
+        self.assertEqual(config["mixed_precision"], "bf16")
+        self.assertNotIn("full_fp16", config)
+        self.assertEqual(config["scale_weight_norms"], 1)
+        self.assertTrue(
+            any("full_matrix=true" in warning for warning in config["_training_warnings"])
+        )
 
     def test_anima_disables_full_bf16_for_automagic(self):
         config = {
@@ -91,6 +115,7 @@ class AnimaTrainingDefaultsTests(unittest.TestCase):
 
         self.assertEqual(config["mixed_precision"], "bf16")
         self.assertNotIn("full_fp16", config)
+        self.assertIn("Changed Anima mixed_precision", config["_training_warnings"][0])
 
     def test_anima_keeps_fp16_when_bf16_is_not_supported(self):
         config = {


### PR DESCRIPTION
# Draft PR - Issue #127

## Title

`fix: harden Anima LoKr dtype and LyCORIS defaults`

## Branch

`pr/issue-127-anima-lokr-guardrails`

## Base

Recommended: `main` unless maintainers request `dev`.

## Related Issue

`Refs #127`

## Body

```md
## Summary

- Add Anima LoKr dtype guardrails for bf16-compatible paths.
- Avoid applying full precision guardrails to incompatible optimizer combinations such as CAME/Automagic.
- Normalize LyCORIS/LoKr arguments into `network_args`.
- Surface training warnings through task metadata where applicable.
- Add Anima training defaults, backend adapter, and train routing regression coverage.

## Validation

- `python -m pytest tests/test_anima_training_defaults.py tests/test_anima_backend_adapter.py tests/test_train_routing.py -q`

## Boundaries

- This PR reduces known Anima LoKr dtype/default failure modes.
- Local validation does not guarantee all RTX 3090, 800+ image, multi-epoch, preview-on, or batch>1 jobs are fixed.
- The issue should remain open until maintainers and affected users confirm the target branch in real workloads.

Refs #127
```

## Candidate Files

- `mikazuki/app/api.py`
- Anima backend adapter/routing files if the final split includes network arg normalization there.
- `tests/test_anima_training_defaults.py`
- `tests/test_anima_backend_adapter.py`
- `tests/test_train_routing.py`

## Notes For Split

Keep #127 focused on dtype/default guardrails and LyCORIS/LoKr argument normalization. Do not overstate validation; this issue is hardware and dataset dependent.

