### PR TITLE
fix: gate preview sample generation

### DIFF
--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -317,7 +317,15 @@ def apply_sdxl_prediction_type(config: dict, model_train_type: str):
 
 
 def is_preview_enabled(config: dict) -> bool:
-    return config.get("enable_preview") in (True, "true", "True", "1", 1)
+    return train_utils.is_preview_enabled(config)
+
+
+def has_explicit_sample_prompt_source(config: dict) -> bool:
+    return train_utils.has_explicit_sample_prompt_source(config)
+
+
+def should_generate_sample_prompts(config: dict) -> bool:
+    return train_utils.should_generate_sample_prompts(config)
 
 
 def _detect_best_attn_mode() -> str:
@@ -631,7 +639,7 @@ async def create_toml_file(request: Request):
             return APIResponseFail(message=f"Prompt 文件 {prompt_file} 不存在，请检查路径。")
         config["sample_prompts"] = prompt_file
         train_utils.normalize_sample_prompt_file(prompt_file)
-    else:
+    elif should_generate_sample_prompts(config):
         try:
             positive_prompt, sample_prompts_arg = get_sample_prompts(config=config, model_train_type=model_train_type)
 
@@ -645,6 +653,8 @@ async def create_toml_file(request: Request):
         except ValueError as e:
             log.error(f"Error while processing prompts: {e}")
             return APIResponseFail(message=str(e))
+    else:
+        train_utils.strip_disabled_preview_fields(config)
 
     if config.get("sample_prompts"):
         train_utils.normalize_sample_prompt_file(str(config["sample_prompts"]))

--- a/mikazuki/utils/train_utils.py
+++ b/mikazuki/utils/train_utils.py
@@ -11,6 +11,22 @@ from mikazuki.log import log
 
 python_bin = sys.executable
 
+PREVIEW_UI_FIELDS = (
+    "positive_prompts",
+    "negative_prompts",
+    "sample_width",
+    "sample_height",
+    "sample_cfg",
+    "sample_seed",
+    "sample_steps",
+    "sample_sampler",
+    "randomly_choice_prompt",
+    "sample_at_first",
+    "sample_every_n_epochs",
+    "sample_every_n_steps",
+    "prompt_file",
+)
+
 
 class ModelType(Enum):
     UNKNOWN = -1
@@ -82,6 +98,27 @@ def is_promopt_like(s):
         if p in s:
             return True
     return False
+
+
+def is_preview_enabled(config: dict) -> bool:
+    return config.get("enable_preview") in (True, "true", "True", "1", 1)
+
+
+def has_explicit_sample_prompt_source(config: dict) -> bool:
+    prompt_file = str(config.get("prompt_file") or "").strip()
+    if prompt_file:
+        return True
+    sample_prompts = str(config.get("sample_prompts") or "").strip()
+    return bool(sample_prompts)
+
+
+def should_generate_sample_prompts(config: dict) -> bool:
+    return is_preview_enabled(config) or has_explicit_sample_prompt_source(config)
+
+
+def strip_disabled_preview_fields(config: dict) -> None:
+    for key in PREVIEW_UI_FIELDS:
+        config.pop(key, None)
 
 
 def normalize_sample_prompt_text(text: str) -> str:

--- a/tests/test_train_utils_preview_gate.py
+++ b/tests/test_train_utils_preview_gate.py
@@ -1,0 +1,87 @@
+import unittest
+
+from mikazuki.utils import train_utils
+
+
+class TrainUtilsPreviewGateTests(unittest.TestCase):
+    def test_disabled_preview_does_not_generate_from_ui_prompt_fields(self):
+        config = {
+            "enable_preview": False,
+            "positive_prompts": "1girl, solo",
+            "negative_prompts": "lowres",
+            "sample_width": 1024,
+            "sample_height": 1024,
+            "sample_cfg": 4.5,
+            "sample_seed": 42,
+            "sample_steps": 40,
+            "sample_sampler": "euler",
+            "randomly_choice_prompt": False,
+            "sample_at_first": True,
+            "sample_every_n_epochs": 1,
+            "sample_every_n_steps": 10,
+            "prompt_file": "",
+            "train_data_dir": "./train",
+        }
+
+        self.assertFalse(train_utils.should_generate_sample_prompts(config))
+        train_utils.strip_disabled_preview_fields(config)
+
+        for key in train_utils.PREVIEW_UI_FIELDS:
+            self.assertNotIn(key, config)
+        self.assertEqual(config["enable_preview"], False)
+        self.assertEqual(config["train_data_dir"], "./train")
+
+    def test_enabled_preview_generates_from_ui_prompt_fields(self):
+        config = {
+            "enable_preview": "true",
+            "positive_prompts": "1girl, solo",
+            "negative_prompts": "lowres",
+            "sample_width": 1024,
+            "sample_height": 1024,
+            "sample_cfg": 4.5,
+            "sample_steps": 40,
+            "sample_seed": 42,
+            "sample_sampler": "euler",
+            "train_data_dir": "./train",
+        }
+
+        self.assertTrue(train_utils.should_generate_sample_prompts(config))
+        line = train_utils.build_sample_prompt_line(
+            config["positive_prompts"],
+            config["negative_prompts"],
+            width=config["sample_width"],
+            height=config["sample_height"],
+            cfg=config["sample_cfg"],
+            steps=config["sample_steps"],
+            seed=config["sample_seed"],
+            sampler=config["sample_sampler"],
+        )
+        self.assertIn("--w 1024", line)
+        self.assertIn("--h 1024", line)
+        self.assertIn("--l 4.5", line)
+        self.assertIn("--s 40", line)
+        self.assertIn("--d 42", line)
+        self.assertIn("--ss euler", line)
+
+    def test_explicit_prompt_file_generates_even_without_preview_toggle(self):
+        config = {
+            "enable_preview": False,
+            "prompt_file": "E:/prompts.txt",
+            "train_data_dir": "./train",
+        }
+
+        self.assertTrue(train_utils.should_generate_sample_prompts(config))
+
+    def test_explicit_sample_prompts_generates_even_without_preview_toggle(self):
+        config = {
+            "enable_preview": False,
+            "sample_prompts": "E:/prompts.txt",
+            "train_data_dir": "./train",
+        }
+
+        self.assertTrue(train_utils.should_generate_sample_prompts(config))
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
# Draft PR - Issue #120

## Title

`fix: gate preview sample generation`

## Branch

`pr/issue-120-preview-gate`

## Base

Recommended: `main` unless maintainers request `dev`.

## Related Issue

`Refs #120`

## Body

```md
## Summary

- Gate sample prompt generation behind the preview switch.
- Strip preview/sample UI fields when preview is disabled and no explicit prompt source is provided.
- Preserve explicit `prompt_file` / `sample_prompts` behavior.
- Add regression coverage for preview off/on config output.

## Validation

- `python -m pytest tests/test_train_utils_preview_gate.py tests/test_sample_prompt_normalization.py -q`

## Boundaries

- This PR addresses the training-start baseline image generated while preview is disabled.
- It does not claim generic coverage for every SD1.5/SDXL/Flux/Lumina model family without corresponding resources.

Refs #120
```

## Candidate Files

- `mikazuki/utils/train_utils.py`
- `mikazuki/app/api.py`
- `tests/test_train_utils_preview_gate.py`
- Possible related sample prompt tests.

## Notes For Split

Keep only preview gate changes. Avoid carrying #125 standard training metadata, #126 Fast log defaults, or #127 Anima LoKr guardrails into this PR unless required by shared helper extraction.

