### PR TITLE
[codex] fix Anima LoKr learning rate fallback

### DIFF
--- a/mikazuki/anima_backend/adapter.py
+++ b/mikazuki/anima_backend/adapter.py
@@ -244,6 +244,15 @@ def _normalize_network_args(values: Any) -> list[str]:
     return ordered
 
 
+def _apply_lr_fallback(source: dict[str, Any]) -> None:
+    learning_rate = source.get("learning_rate")
+    if _is_empty_value(learning_rate):
+        return
+    for key in ("unet_lr", "text_encoder_lr"):
+        if _is_empty_value(source.get(key)):
+            source[key] = learning_rate
+
+
 def adapt_anima_config(
     config: dict[str, Any], *, finetune: bool = False
 ) -> tuple[dict[str, Any], list[str]]:
@@ -270,6 +279,8 @@ def adapt_anima_config(
             source["network_args"] = normalized_network_args
         elif "network_args" in source:
             source.pop("network_args", None)
+
+        _apply_lr_fallback(source)
 
     # LyCORIS default preset does not include Anima module class names, which may
     # produce zero trainable modules for LoKr. Inject Anima-specific preset unless

--- a/tests/test_anima_backend_adapter.py
+++ b/tests/test_anima_backend_adapter.py
@@ -194,6 +194,36 @@ class AnimaBackendAdapterTests(unittest.TestCase):
         self.assertIn("dropout=0", na)
         self.assertIn("module_dropout=0.0", na)
 
+    def test_learning_rate_fills_missing_component_lrs(self):
+        config = {
+            "network_module": "lycoris.kohya",
+            "lycoris_algo": "lokr",
+            "network_train_unet_only": True,
+            "learning_rate": "1",
+            "unet_lr": "",
+            "text_encoder_lr": "",
+        }
+        adapted, warnings = adapt_anima_config(config)
+
+        self.assertEqual(adapted["learning_rate"], "1")
+        self.assertEqual(adapted["unet_lr"], "1")
+        self.assertEqual(adapted["text_encoder_lr"], "1")
+        self.assertEqual(warnings, [])
+
+    def test_learning_rate_does_not_override_component_lrs(self):
+        config = {
+            "network_module": "lycoris.kohya",
+            "lycoris_algo": "lokr",
+            "learning_rate": "1",
+            "unet_lr": "5e-5",
+            "text_encoder_lr": "1e-5",
+        }
+        adapted, warnings = adapt_anima_config(config)
+
+        self.assertEqual(adapted["unet_lr"], "5e-5")
+        self.assertEqual(adapted["text_encoder_lr"], "1e-5")
+        self.assertEqual(warnings, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed
- Added a backend fallback so Anima LoKr uses `learning_rate` to populate missing `unet_lr` and `text_encoder_lr`.
- Added regression coverage for the fallback and for preserving explicit component LRs.

## Why
- Anima LoKr training could end up with an empty optimizer param list when only the total learning rate was filled in the UI, which led to `IndexError` before optimizer creation.
- The backend now matches the intended UX: the total LR can safely act as a fallback instead of forcing users to enter all three fields.

## Validation
- `I:\Conda\envs\lora-scripts\python.exe -m pytest tests/test_anima_backend_adapter.py tests/test_anima_training_defaults.py`
- `I:\Conda\envs\lora-scripts\python.exe -m pytest`
- Manual gray test: verified `adapt_anima_config(...)` fills missing component LRs when only `learning_rate=1` is provided.
- Full pytest now runs to completion in the project Conda env; 4 unrelated existing failures remain in `tests/test_anima_backend_upstream.py` and `vendor/sd-scripts/tests/test_optimizer.py`.