### PR TITLE
docs(presets): add Anima LoRA import presets

### DIFF
--- a/config/presets/anima-fast-lora-character.toml
+++ b/config/presets/anima-fast-lora-character.toml
@@ -1,0 +1,33 @@
+[metadata]
+name = "Anima Fast LoRA - 角色通用"
+version = "1.0"
+author = "SD-Trainer Next"
+train_type = "anima-lora-fast"
+description = "适合需要更快训练的角色 LoRA。Fast 插件当前不支持 Automagic，因此使用 AdamW8bit。"
+
+[data]
+method = "lora"
+network_module = "networks.lora_anima"
+network_dim = 16
+network_alpha = 16
+
+resolution = "1024,1024"
+enable_bucket = true
+train_batch_size = 1
+gradient_checkpointing = true
+
+optimizer_type = "AdamW8bit"
+learning_rate = 0.0001
+
+mixed_precision = "bf16"
+cache_latents = false
+cache_latents_to_disk = false
+cache_text_encoder_outputs = false
+cache_text_encoder_outputs_to_disk = false
+skip_cache_check = true
+
+torch_compile = true
+static_token_count = 4096
+compile_mode = "blocks"
+dynamo_backend = "inductor"
+attn_mode = "flash"

--- a/config/presets/anima-fast-lora-style.toml
+++ b/config/presets/anima-fast-lora-style.toml
@@ -1,0 +1,33 @@
+[metadata]
+name = "Anima Fast LoRA - 画风通用"
+version = "1.0"
+author = "SD-Trainer Next"
+train_type = "anima-lora-fast"
+description = "适合需要更快产出的画风 LoRA。Fast 插件当前不支持 Automagic，因此使用 AdamW8bit。"
+
+[data]
+method = "lora"
+network_module = "networks.lora_anima"
+network_dim = 32
+network_alpha = 16
+
+resolution = "1024,1024"
+enable_bucket = true
+train_batch_size = 1
+gradient_checkpointing = true
+
+optimizer_type = "AdamW8bit"
+learning_rate = 0.00005
+
+mixed_precision = "bf16"
+cache_latents = false
+cache_latents_to_disk = false
+cache_text_encoder_outputs = false
+cache_text_encoder_outputs_to_disk = false
+skip_cache_check = true
+
+torch_compile = true
+static_token_count = 4096
+compile_mode = "blocks"
+dynamo_backend = "inductor"
+attn_mode = "flash"

--- a/config/presets/anima-lora-character-automagic.toml
+++ b/config/presets/anima-lora-character-automagic.toml
@@ -1,0 +1,40 @@
+[metadata]
+name = "Anima LoRA - 角色通用（Automagic）"
+version = "1.0"
+author = "SD-Trainer Next"
+train_type = "anima-lora"
+description = "适合单角色、服装、道具等常规角色 LoRA。使用 Automagic，适合新手作为默认预设。"
+
+[data]
+lora_type = "lora"
+network_module = "networks.lora_anima"
+network_dim = 16
+network_alpha = 16
+network_train_unet_only = true
+network_train_text_encoder_only = false
+
+resolution = "1024,1024"
+enable_bucket = true
+min_bucket_reso = 256
+max_bucket_reso = 1024
+bucket_reso_steps = 64
+bucket_no_upscale = false
+
+train_batch_size = 1
+gradient_checkpointing = true
+gradient_accumulation_steps = 1
+
+optimizer_type = "Automagic"
+learning_rate = 0.0001
+unet_lr = 0.0001
+text_encoder_lr = 0
+lr_scheduler = "constant"
+lr_warmup_steps = 0
+
+mixed_precision = "bf16"
+save_precision = "bf16"
+cache_latents = true
+cache_latents_to_disk = true
+cache_text_encoder_outputs = true
+cache_text_encoder_outputs_to_disk = true
+max_data_loader_n_workers = 2

--- a/config/presets/anima-lora-style-automagic.toml
+++ b/config/presets/anima-lora-style-automagic.toml
@@ -1,0 +1,40 @@
+[metadata]
+name = "Anima LoRA - 画风通用（Automagic）"
+version = "1.0"
+author = "SD-Trainer Next"
+train_type = "anima-lora"
+description = "适合画风、上色、光影、构图和质感训练。使用 Automagic，隐藏学习率和调度器细节。"
+
+[data]
+lora_type = "lora"
+network_module = "networks.lora_anima"
+network_dim = 32
+network_alpha = 16
+network_train_unet_only = true
+network_train_text_encoder_only = false
+
+resolution = "1024,1024"
+enable_bucket = true
+min_bucket_reso = 256
+max_bucket_reso = 1024
+bucket_reso_steps = 64
+bucket_no_upscale = false
+
+train_batch_size = 1
+gradient_checkpointing = true
+gradient_accumulation_steps = 1
+
+optimizer_type = "Automagic"
+learning_rate = 0.00005
+unet_lr = 0.00005
+text_encoder_lr = 0
+lr_scheduler = "constant"
+lr_warmup_steps = 0
+
+mixed_precision = "bf16"
+save_precision = "bf16"
+cache_latents = true
+cache_latents_to_disk = true
+cache_text_encoder_outputs = true
+cache_text_encoder_outputs_to_disk = true
+max_data_loader_n_workers = 2

--- a/docs/anima-lora-presets.md
+++ b/docs/anima-lora-presets.md
@@ -1,0 +1,36 @@
+# Anima LoRA Presets
+
+This page lists the first batch of importable Anima LoRA preset TOML files.
+They are intended as practical starting points for product integrations, not as
+fixed best settings for every dataset.
+
+## Standard LoRA
+
+- [Character LoRA (Automagic)](../config/presets/anima-lora-character-automagic.toml)  
+  For single characters, outfits, props, and general character LoRA training.
+
+- [Style LoRA (Automagic)](../config/presets/anima-lora-style-automagic.toml)  
+  For art style, coloring, lighting, composition, and texture training.
+
+Standard LoRA presets use `Automagic` to reduce the need for beginners to tune
+learning rate and scheduler settings manually.
+
+## Fast LoRA
+
+- [Fast Character LoRA](../config/presets/anima-fast-lora-character.toml)  
+  For faster character LoRA training with the Anima Fast plugin runtime.
+
+- [Fast Style LoRA](../config/presets/anima-fast-lora-style.toml)  
+  For faster style LoRA training with the Anima Fast plugin runtime.
+
+Fast LoRA currently uses `AdamW8bit` because the Anima Fast plugin runtime does
+not support `Automagic`.
+
+## Notes
+
+- These presets intentionally do not include LoKr, T-LoRA, or full finetune
+  presets. Those modes are more sensitive to VRAM, dependency versions, speed,
+  and parameter combinations, and should be tested separately as advanced
+  presets.
+- Before exposing presets to end users, test them on 100-300 representative
+  images from the target dataset category and verify generated previews.


### PR DESCRIPTION
## Summary

- Add four importable Anima preset TOMLs under `config/presets/`:
  - standard character LoRA with `Automagic`
  - standard style LoRA with `Automagic`
  - Fast character LoRA with `AdamW8bit`
  - Fast style LoRA with `AdamW8bit`
- Add `docs/anima-lora-presets.md` as a lightweight partner-facing index that links directly to the preset files.
- Keep LoKr / T-LoRA / full finetune out of the first preset batch because they need separate advanced testing.

## Test plan

- `python -c "... toml.loads(...) ..."` parses all four new preset TOML files and confirms their `train_type`.
