### PR TITLE
fix(anima): guard LoKr train_norm

### DIFF
--- a/mikazuki/anima_backend/adapter.py
+++ b/mikazuki/anima_backend/adapter.py
@@ -193,6 +193,11 @@ LYCORIS_NETWORK_ARG_MAP: dict[str, str] = {
     "dropout": "dropout",
 }
 
+LOKR_TRAIN_NORM_WARNING = (
+    "LyCORIS train_norm is disabled for Anima LoKr because LyCORIS NormModule "
+    "can crash on Anima norm layers without affine weights during preview sampling."
+)
+
 
 def _is_empty_value(value: Any) -> bool:
     """Check if a value is empty/invalid (None, NaN, 'undefined', 'null', '')."""
@@ -253,6 +258,30 @@ def _apply_lr_fallback(source: dict[str, Any]) -> None:
             source[key] = learning_rate
 
 
+def _network_args_use_lokr(network_args: list[str]) -> bool:
+    for item in network_args:
+        if not isinstance(item, str) or "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        if key.strip().lower() == "algo" and value.strip().lower() == "lokr":
+            return True
+    return False
+
+
+def _strip_arg(network_args: list[str], arg_key: str) -> tuple[list[str], bool]:
+    stripped: list[str] = []
+    removed = False
+    target = arg_key.strip().lower()
+    for item in network_args:
+        if isinstance(item, str) and "=" in item:
+            key, _value = item.split("=", 1)
+            if key.strip().lower() == target:
+                removed = True
+                continue
+        stripped.append(item)
+    return stripped, removed
+
+
 def adapt_anima_config(
     config: dict[str, Any], *, finetune: bool = False
 ) -> tuple[dict[str, Any], list[str]]:
@@ -309,6 +338,10 @@ def adapt_anima_config(
             if _is_empty_value(value):
                 continue
             network_args.append(f"{arg_key}={value}")
+        if _network_args_use_lokr(network_args):
+            network_args, removed_train_norm = _strip_arg(network_args, "train_norm")
+            if removed_train_norm:
+                warnings.append(LOKR_TRAIN_NORM_WARNING)
         if network_args:
             source["network_args"] = network_args
 

--- a/mikazuki/schema/shared.ts
+++ b/mikazuki/schema/shared.ts
@@ -50,7 +50,7 @@
                 conv_dim: Schema.number().default(4),
                 conv_alpha: Schema.number().default(1),
                 dropout: Schema.number().step(0.01).default(0).description('dropout 概率。推荐 0~0.5，LoHa/LoKr/(IA)^3暂不支持'),
-                train_norm: Schema.boolean().default(false).description('训练 Norm 层，不支持 (IA)^3'),
+                train_norm: Schema.boolean().default(false).description('训练 Norm 层，不支持 (IA)^3。Anima LoKr 会自动禁用 train_norm 以避免 LyCORIS NormModule 采样崩溃。'),
             }),
             Schema.object({}),
         ]),

--- a/tests/test_anima_backend_adapter.py
+++ b/tests/test_anima_backend_adapter.py
@@ -194,6 +194,33 @@ class AnimaBackendAdapterTests(unittest.TestCase):
         self.assertIn("dropout=0", na)
         self.assertIn("module_dropout=0.0", na)
 
+    def test_lokr_train_norm_is_disabled_with_warning(self):
+        config = {
+            "network_module": "lycoris.kohya",
+            "lycoris_algo": "lokr",
+            "train_norm": True,
+        }
+
+        adapted, warnings = adapt_anima_config(config)
+
+        self.assertIn("network_args", adapted)
+        self.assertIn("algo=lokr", adapted["network_args"])
+        self.assertNotIn("train_norm=True", adapted["network_args"])
+        self.assertTrue(any("train_norm" in warning and "LoKr" in warning for warning in warnings))
+
+    def test_lycoris_non_lokr_keeps_train_norm(self):
+        config = {
+            "network_module": "lycoris.kohya",
+            "lycoris_algo": "locon",
+            "train_norm": True,
+        }
+
+        adapted, warnings = adapt_anima_config(config)
+
+        self.assertIn("algo=locon", adapted["network_args"])
+        self.assertIn("train_norm=True", adapted["network_args"])
+        self.assertEqual(warnings, [])
+
     def test_learning_rate_fills_missing_component_lrs(self):
         config = {
             "network_module": "lycoris.kohya",

--- a/tests/test_anima_training_defaults.py
+++ b/tests/test_anima_training_defaults.py
@@ -5,6 +5,16 @@ from mikazuki.app.api import apply_anima_training_defaults
 
 
 class AnimaTrainingDefaultsTests(unittest.TestCase):
+    def test_schema_notes_lokr_train_norm_guardrail(self):
+        from pathlib import Path
+
+        schema = (Path(__file__).resolve().parents[1] / "mikazuki" / "schema" / "shared.ts").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("Anima LoKr", schema)
+        self.assertIn("train_norm", schema)
+
     def test_anima_does_not_auto_enable_full_bf16_for_non_lokr(self):
         config = {
             "mixed_precision": "bf16",


### PR DESCRIPTION
## Summary
- Disable LyCORIS train_norm when adapting Anima LoKr configs.
- Preserve train_norm for non-LoKr LyCORIS algorithms.
- Update schema copy to warn that Anima LoKr automatically disables train_norm.

## Why
Issue #136 reports a crash during preview sampling when LoKr and train_norm are enabled together. LyCORIS NormModule assumes norm layers have affine weights, but some Anima norm layers do not, leading to AttributeError during sampling.

## Validation
- RED: python -m pytest tests/test_anima_backend_adapter.py -q failed before the guard because 	rain_norm=True was still emitted for LoKr.
- GREEN: python -m pytest tests/test_anima_backend_adapter.py -q
- python -m pytest tests/test_anima_backend_adapter.py tests/test_anima_training_defaults.py tests/test_train_routing.py -q
- git diff --check

Closes #136