### PR TITLE
Fix Prodigy LR curves in train monitor

### DIFF
--- a/tests/test_train_monitor_status.py
+++ b/tests/test_train_monitor_status.py
@@ -8,6 +8,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from torch.utils.tensorboard import SummaryWriter
+
 from train_monitor import server
 
 
@@ -323,6 +325,31 @@ class TrainMonitorStatusTests(unittest.TestCase):
     def test_tensorboard_scalar_tags_include_anima_finetune_loss(self):
         self.assertIn("loss", server.TENSORBOARD_SCALAR_TAGS)
         self.assertIn("loss/epoch", server.TENSORBOARD_SCALAR_TAGS)
+
+    def test_tensorboard_scalars_include_prodigy_effective_lr_tags(self):
+        with tempfile.TemporaryDirectory() as td:
+            log_dir = Path(td) / "logs" / "run"
+            writer = SummaryWriter(str(log_dir))
+            try:
+                for step in range(1, 4):
+                    writer.add_scalar("loss", 0.3 / step, step)
+                    writer.add_scalar("lr", 0.01 * step, step)
+                    writer.add_scalar("lr/base", 1.0, step)
+                    writer.add_scalar("lr/d*lr/base", 0.001 * step, step)
+                    writer.add_scalar("lr/d*eff_lr/base", 0.002 * step, step)
+            finally:
+                writer.close()
+
+            with mock.patch.object(server, "LOG_DIR", Path(td) / "logs"):
+                series = server.tensorboard_loss_scalars()
+
+        by_tag = {item["tag"]: item for item in series}
+        self.assertIn("lr", by_tag)
+        self.assertIn("lr/d*lr/base", by_tag)
+        self.assertIn("lr/d*eff_lr/base", by_tag)
+        self.assertAlmostEqual(by_tag["lr"]["latest"], 0.03, places=6)
+        self.assertAlmostEqual(by_tag["lr/d*lr/base"]["latest"], 0.003, places=6)
+        self.assertAlmostEqual(by_tag["lr/d*eff_lr/base"]["latest"], 0.006, places=6)
 
     def test_collect_status_exposes_log_loss_points_without_tensorboard(self):
         log_lines = [

--- a/train_monitor/monitor.js
+++ b/train_monitor/monitor.js
@@ -706,7 +706,7 @@ function renderLossChart(metrics, status) {
       : "真实 scalar 曲线，和 TensorBoard 同源") + '</span>';
 
   area.className = "tb-loss-grid";
-  const hasLearningRate = series.some(function(item) { return /^lr\//.test(item.tag); });
+  const hasLearningRate = series.some(function(item) { return item.tag === "lr" || /^lr\//.test(item.tag); });
   const displaySeries = hasLearningRate ? series : series.concat([{
     tag: "lr",
     name: "learning rate",

--- a/train_monitor/server.py
+++ b/train_monitor/server.py
@@ -63,6 +63,7 @@ TENSORBOARD_SCALAR_TAGS = (
     "lr/llm_adapter",
 )
 TENSORBOARD_LOSS_LIMIT = 10000
+TENSORBOARD_LR_TAG_PREFIXES = ("lr/",)
 
 STRONG_ERROR_PATTERNS = [
     r"\btraceback\b",
@@ -396,13 +397,13 @@ def tensorboard_loss_scalars(limit: int = TENSORBOARD_LOSS_LIMIT) -> list[dict]:
             continue
 
         series = []
-        for tag in TENSORBOARD_SCALAR_TAGS:
-            if tag not in scalar_tags:
-                continue
+        run_label = str(run_dir.relative_to(REPO)) if run_dir.is_relative_to(REPO) else str(run_dir)
+
+        def scalar_series(tag: str) -> dict | None:
             try:
                 events = accumulator.Scalars(tag)[-limit:]
             except Exception:
-                continue
+                return None
             points = [
                 {
                     "step": int(event.step),
@@ -411,17 +412,33 @@ def tensorboard_loss_scalars(limit: int = TENSORBOARD_LOSS_LIMIT) -> list[dict]:
                 for event in events
             ]
             if not points:
-                continue
+                return None
             values = [point["value"] for point in points]
-            series.append({
+            return {
                 "tag": tag,
                 "name": tag.split("/", 1)[-1].replace("_", " "),
                 "points": points,
                 "latest": values[-1],
                 "min": min(values),
                 "max": max(values),
-                "run": str(run_dir.relative_to(REPO)) if run_dir.is_relative_to(REPO) else str(run_dir),
-            })
+                "run": run_label,
+            }
+
+        for tag in TENSORBOARD_SCALAR_TAGS:
+            if tag not in scalar_tags:
+                continue
+            item = scalar_series(tag)
+            if item:
+                series.append(item)
+
+        for tag in sorted(scalar_tags):
+            if tag != "lr" and not any(tag.startswith(prefix) for prefix in TENSORBOARD_LR_TAG_PREFIXES):
+                continue
+            if any(item["tag"] == tag for item in series):
+                continue
+            item = scalar_series(tag)
+            if item:
+                series.append(item)
         if series:
             return series
 


### PR DESCRIPTION
## Summary
- Include all TensorBoard `lr` and `lr/...` scalar curves in the training monitor, including Prodigy/DAdapt effective LR tags such as `lr/d*lr/...` and `lr/d*eff_lr/...`.
- Treat plain `lr` as a learning-rate curve in the monitor UI so it does not show the missing LR placeholder.
- Add a regression test with synthetic TensorBoard events that reproduces the missing Prodigy LR curves.

Closes #138

## Verification
- Reproduced current behavior with synthetic TensorBoard events: existing monitor returned only `loss` and `lr/base`, omitting `lr/d*lr/base` and `lr/d*eff_lr/base`.
- After the fix, the same synthetic event log returns `loss`, `lr/base`, `lr`, `lr/d*eff_lr/base`, and `lr/d*lr/base`.
- `python -m pytest tests/test_train_monitor_status.py -q` -> 18 passed, 1 warning
- `git diff --check` -> no errors