### PR TITLE
fix(sdxl): route WebUI LoRA to vendor trainer

### DIFF
--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -105,7 +105,7 @@ avaliable_presets = []
 
 trainer_mapping = {
     "sd-lora": "./scripts/stable/train_network.py",
-    "sdxl-lora": "./scripts/stable/sdxl_train_network.py",
+    "sdxl-lora": "./vendor/sd-scripts/sdxl_train_network.py",
 
     "sd-dreambooth": "./scripts/stable/train_db.py",
     "sdxl-finetune": "./scripts/stable/sdxl_train.py",

--- a/tests/test_standard_run_api.py
+++ b/tests/test_standard_run_api.py
@@ -106,6 +106,42 @@ class StandardRunApiTests(unittest.TestCase):
             self.assertEqual(trainer_file, "./scripts/stable/train_network.py")
             self.assertEqual(cpu_threads, 2)
 
+    def test_run_routes_sdxl_lora_to_vendor_trainer(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            data_dir = root / "dataset"
+            image_dir = data_dir / "1_class"
+            image_dir.mkdir(parents=True)
+            (image_dir / "sample.png").write_bytes(b"not-used-by-mocked-runner")
+            model_path = root / "model.safetensors"
+            model_path.write_bytes(b"not-used-by-mocked-runner")
+
+            payload = {
+                "model_train_type": "sdxl-lora",
+                "train_data_dir": str(data_dir),
+                "pretrained_model_name_or_path": str(model_path),
+                "output_dir": str(root / "output"),
+                "output_name": "unit-sdxl-lora",
+                "enable_preview": False,
+            }
+            fake_response = api.APIResponseSuccess(
+                message="Training started",
+                data={
+                    "task_id": "task-sdxl",
+                    "metadata": {"backend": "standard", "trainer_file": "./vendor/sd-scripts/sdxl_train_network.py"},
+                },
+            )
+
+            with mock.patch.object(api.os, "getcwd", return_value=str(root)), \
+                    mock.patch.object(api.process, "run_train", return_value=fake_response) as run_train:
+                response = asyncio.run(api.create_toml_file(make_request(payload)))
+
+            self.assertEqual(response.status, "success")
+            run_train.assert_called_once()
+            _toml_path, trainer_file, _gpu_ids, cpu_threads = run_train.call_args.args
+            self.assertEqual(trainer_file, "./vendor/sd-scripts/sdxl_train_network.py")
+            self.assertEqual(cpu_threads, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_train_routing.py
+++ b/tests/test_train_routing.py
@@ -34,7 +34,7 @@ class TrainRoutingTests(unittest.TestCase):
         mapping = load_trainer_mapping()
 
         self.assertEqual(mapping["sd-lora"], "./scripts/stable/train_network.py")
-        self.assertEqual(mapping["sdxl-lora"], "./scripts/stable/sdxl_train_network.py")
+        self.assertEqual(mapping["sdxl-lora"], "./vendor/sd-scripts/sdxl_train_network.py")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Route WebUI/API `sdxl-lora` training to `./vendor/sd-scripts/sdxl_train_network.py`, the SDXL trainer path that is currently executable with the vendored strategy stack.
- Keep non-SDXL standard training routes unchanged.
- Add routing/API regression tests so `model_train_type=sdxl-lora` cannot silently drift back to the half-synced stable wrapper.

Fixes #145.

## Verification

- `D:\ai\lora-scripts-next\venv\Scripts\python.exe -m pytest tests/test_train_routing.py tests/test_standard_run_api.py tests/test_sdxl_stable_trainer_contract.py tests/test_tagger_ort_session.py -q`
  - Result: `13 passed`
- Real SDXL smoke training through the WebUI backend chain was run locally:
  - `create_toml_file()` / `/api/run` payload with `model_train_type = sdxl-lora`
  - `process.run_train()` / TaskManager
  - `accelerate.commands.launch`
  - `./vendor/sd-scripts/sdxl_train_network.py`
  - Result: `20/20` steps, return code `0`
  - Artifact: `D:\ai\lora-scripts-next-sdxl-webui-fix\output\sdxl_api_smoke\sdxl_api_smoke.safetensors`