### PR TITLE
fix(anima-fast): reject incomplete ready runtime

### DIFF
--- a/mikazuki/anima_fast_backend/extension_state.py
+++ b/mikazuki/anima_fast_backend/extension_state.py
@@ -42,6 +42,14 @@ class ExtensionLayout:
     def train_py(self) -> Path:
         return self.source / "train.py"
 
+    @property
+    def base_config(self) -> Path:
+        return self.source / "configs" / "base.toml"
+
+    @property
+    def resize_script(self) -> Path:
+        return self.source / "preprocess" / "resize_images.py"
+
 
 @dataclass(frozen=True)
 class ExtensionStatus:
@@ -124,13 +132,28 @@ def write_install_state(layout: ExtensionLayout, state: str, facts: dict | None 
     layout.install_state.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
+def _missing_runtime_files(layout: ExtensionLayout) -> list[str]:
+    required = (
+        (layout.train_py, "train.py"),
+        (layout.base_config, "configs/base.toml"),
+        (layout.resize_script, "preprocess/resize_images.py"),
+    )
+    return [label for path, label in required if not path.is_file()]
+
+
 def read_extension_status(layout: ExtensionLayout) -> ExtensionStatus:
     if not layout.root.exists():
         return ExtensionStatus(STATE_NOT_INSTALLED, str(layout.source), str(layout.venv_python), "extension root missing")
     if not layout.source.exists():
         return ExtensionStatus(STATE_NOT_INSTALLED, str(layout.source), str(layout.venv_python), "source missing")
-    if not layout.train_py.is_file():
-        return ExtensionStatus(STATE_BROKEN, str(layout.source), str(layout.venv_python), "train.py missing")
+    missing = _missing_runtime_files(layout)
+    if missing and not layout.install_state.is_file():
+        return ExtensionStatus(
+            STATE_BROKEN,
+            str(layout.source),
+            str(layout.venv_python),
+            "required runtime file(s) missing: " + ", ".join(missing),
+        )
     if not layout.venv_python.is_file():
         return ExtensionStatus(STATE_INSTALLED_UNVERIFIED, str(layout.source), str(layout.venv_python), "python missing")
     if not layout.install_state.is_file():
@@ -143,6 +166,21 @@ def read_extension_status(layout: ExtensionLayout) -> ExtensionStatus:
 
     state = payload.get("state") or STATE_INSTALLED_UNVERIFIED
     facts = payload.get("facts") or {}
+    if state in {STATE_INSTALLING, STATE_AUDITING}:
+        reason = payload.get("reason", "")
+        state, facts, reason = _reconcile_stale_install_state(layout, state, facts, reason)
+        if state in {STATE_INSTALLING, STATE_AUDITING}:
+            return ExtensionStatus(state, str(layout.source), str(layout.venv_python), "", facts)
+        if state == STATE_BROKEN:
+            return ExtensionStatus(STATE_BROKEN, str(layout.source), str(layout.venv_python), reason, facts)
+    if missing:
+        return ExtensionStatus(
+            STATE_BROKEN,
+            str(layout.source),
+            str(layout.venv_python),
+            "required runtime file(s) missing: " + ", ".join(missing),
+            facts,
+        )
     if state == STATE_READY and not facts.get("audit", {}).get("ok"):
         return ExtensionStatus(
             STATE_INSTALLED_UNVERIFIED,
@@ -153,8 +191,6 @@ def read_extension_status(layout: ExtensionLayout) -> ExtensionStatus:
         )
     if state in {STATE_READY, STATE_INSTALLING, STATE_AUDITING, STATE_UPDATE_AVAILABLE}:
         reason = payload.get("reason", "")
-        if state in {STATE_INSTALLING, STATE_AUDITING}:
-            state, facts, reason = _reconcile_stale_install_state(layout, state, facts, reason)
         return ExtensionStatus(
             state,
             str(layout.source),

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -14,6 +14,7 @@ from mikazuki.anima_fast_backend.adapter import (
     ensure_fast_run_log_dirs,
 )
 from mikazuki.anima_fast_backend.extension_state import (
+    STATE_BROKEN,
     STATE_INSTALLED_UNVERIFIED,
     STATE_NOT_INSTALLED,
     STATE_READY,
@@ -73,13 +74,20 @@ class ServiceResolverTests(unittest.TestCase):
 
 
 class ExtensionStateTests(unittest.TestCase):
+    def _make_ready_source(self, layout: ExtensionLayout) -> None:
+        layout.source.mkdir(parents=True)
+        layout.train_py.write_text("", encoding="utf-8")
+        (layout.source / "configs").mkdir()
+        (layout.source / "configs" / "base.toml").write_text("", encoding="utf-8")
+        (layout.source / "preprocess").mkdir()
+        (layout.source / "preprocess" / "resize_images.py").write_text("", encoding="utf-8")
+
     def test_status_transitions(self):
         with tempfile.TemporaryDirectory() as td:
             layout = ExtensionLayout(Path(td) / "anima_lora")
 
             self.assertEqual(read_extension_status(layout).state, STATE_NOT_INSTALLED)
-            layout.source.mkdir(parents=True)
-            layout.train_py.write_text("", encoding="utf-8")
+            self._make_ready_source(layout)
             self.assertEqual(read_extension_status(layout).state, STATE_INSTALLED_UNVERIFIED)
             layout.venv_python.parent.mkdir(parents=True)
             layout.venv_python.write_text("", encoding="utf-8")
@@ -89,6 +97,21 @@ class ExtensionStateTests(unittest.TestCase):
 
         self.assertEqual(status.state, STATE_READY)
         self.assertEqual(status.facts["torch"], "ok")
+
+    def test_ready_state_downgrades_when_runtime_files_are_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            layout = ExtensionLayout(Path(td) / "anima_lora")
+            layout.source.mkdir(parents=True)
+            layout.train_py.write_text("", encoding="utf-8")
+            layout.venv_python.parent.mkdir(parents=True)
+            layout.venv_python.write_text("", encoding="utf-8")
+            write_install_state(layout, STATE_READY, {"audit": {"ok": True}})
+
+            status = read_extension_status(layout)
+
+        self.assertEqual(status.state, STATE_BROKEN)
+        self.assertIn("configs/base.toml", status.reason)
+        self.assertIn("preprocess/resize_images.py", status.reason)
 
 
 class InstallerTests(unittest.TestCase):

--- a/tests/test_anima_fast_environment_installer.py
+++ b/tests/test_anima_fast_environment_installer.py
@@ -33,6 +33,14 @@ from mikazuki.tasks import Task, tm
 
 
 class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
+    def _make_runtime_source(self, layout: ExtensionLayout) -> None:
+        layout.source.mkdir(parents=True, exist_ok=True)
+        layout.train_py.write_text("print('train')\n", encoding="utf-8")
+        (layout.source / "configs").mkdir(exist_ok=True)
+        (layout.source / "configs" / "base.toml").write_text("", encoding="utf-8")
+        (layout.source / "preprocess").mkdir(exist_ok=True)
+        (layout.source / "preprocess" / "resize_images.py").write_text("", encoding="utf-8")
+
     def _make_source(self, root: Path) -> Path:
         source = root / "anima_source"
         source.mkdir()
@@ -40,6 +48,8 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
         (source / "pyproject.toml").write_text("[project]\nname='anima-test'\n", encoding="utf-8")
         (source / "configs").mkdir()
         (source / "configs" / "base.toml").write_text("", encoding="utf-8")
+        (source / "preprocess").mkdir()
+        (source / "preprocess" / "resize_images.py").write_text("", encoding="utf-8")
         return source
 
     def _make_constraints(self, project: Path) -> None:
@@ -64,8 +74,7 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
     def test_ready_requires_audit_ok_facts(self):
         with tempfile.TemporaryDirectory() as td:
             layout = ExtensionLayout(Path(td) / "extensions" / "anima_lora")
-            layout.source.mkdir(parents=True)
-            layout.train_py.write_text("", encoding="utf-8")
+            self._make_runtime_source(layout)
             layout.venv_python.parent.mkdir(parents=True)
             layout.venv_python.write_text("", encoding="utf-8")
             from mikazuki.anima_fast_backend.extension_state import write_install_state
@@ -97,8 +106,7 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
                 log("[fake] command completed")
 
             def fake_copy(_plan):
-                layout.source.mkdir(parents=True)
-                layout.train_py.write_text("print('train')\n", encoding="utf-8")
+                self._make_runtime_source(layout)
 
             with mock.patch("mikazuki.anima_fast_backend.environment._uv_command", return_value="uv"), \
                 mock.patch("mikazuki.anima_fast_backend.environment.copy_source_snapshot", side_effect=fake_copy), \
@@ -170,8 +178,7 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             project = Path(td)
             layout = ExtensionLayout(project / "extensions" / "anima_lora")
-            layout.source.mkdir(parents=True)
-            layout.train_py.write_text("", encoding="utf-8")
+            self._make_runtime_source(layout)
             layout.venv_python.parent.mkdir(parents=True)
             layout.venv_python.write_text("", encoding="utf-8")
 
@@ -217,8 +224,7 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
 
             def fake_install(plan, log):
                 attempts["count"] += 1
-                layout.source.mkdir(parents=True, exist_ok=True)
-                layout.train_py.write_text("print('train')\n", encoding="utf-8")
+                self._make_runtime_source(layout)
                 layout.venv_python.parent.mkdir(parents=True, exist_ok=True)
                 layout.venv_python.write_text("", encoding="utf-8")
                 if attempts["count"] == 1:
@@ -407,8 +413,7 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
         ):
             project = Path(td)
             layout = ExtensionLayout(project / "extensions" / "anima_lora")
-            layout.source.mkdir(parents=True)
-            layout.train_py.write_text("", encoding="utf-8")
+            self._make_runtime_source(layout)
             layout.venv_python.parent.mkdir(parents=True)
             layout.venv_python.write_text("", encoding="utf-8")
 
@@ -500,8 +505,7 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
     def test_stale_installing_without_task_marks_broken(self):
         with tempfile.TemporaryDirectory() as td:
             layout = ExtensionLayout(Path(td) / "extensions" / "anima_lora")
-            layout.source.mkdir(parents=True)
-            layout.train_py.write_text("", encoding="utf-8")
+            self._make_runtime_source(layout)
             layout.venv_python.parent.mkdir(parents=True)
             layout.venv_python.write_text("", encoding="utf-8")
             write_install_state(layout, STATE_INSTALLING, {"task_id": "missing-anima-install-task"})
@@ -515,8 +519,7 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
         task_id = "anima-install-reconcile-test"
         with tempfile.TemporaryDirectory() as td:
             layout = ExtensionLayout(Path(td) / "extensions" / "anima_lora")
-            layout.source.mkdir(parents=True)
-            layout.train_py.write_text("", encoding="utf-8")
+            self._make_runtime_source(layout)
             layout.venv_python.parent.mkdir(parents=True)
             layout.venv_python.write_text("", encoding="utf-8")
             audit = {"ok": True, "errors": [], "warnings": [], "facts": {}}

--- a/tests/test_anima_fast_plugin_api.py
+++ b/tests/test_anima_fast_plugin_api.py
@@ -36,6 +36,14 @@ class AnimaFastPluginApiTests(unittest.TestCase):
         else:
             os.environ["LORA_ENABLE_ANIMA_FAST"] = self.previous
 
+    def _make_ready_source(self, layout: ExtensionLayout) -> None:
+        layout.source.mkdir(parents=True)
+        layout.train_py.write_text("", encoding="utf-8")
+        (layout.source / "configs").mkdir()
+        (layout.source / "configs" / "base.toml").write_text("", encoding="utf-8")
+        (layout.source / "preprocess").mkdir()
+        (layout.source / "preprocess" / "resize_images.py").write_text("", encoding="utf-8")
+
     def test_preflight_fail_message_includes_errors(self):
         result = PreflightResult(
             ok=False,
@@ -131,8 +139,7 @@ class AnimaFastPluginApiTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             layout = ExtensionLayout(root / "extensions" / "anima_lora")
-            layout.source.mkdir(parents=True)
-            layout.train_py.write_text("", encoding="utf-8")
+            self._make_ready_source(layout)
             layout.venv_python.parent.mkdir(parents=True)
             layout.venv_python.write_text("", encoding="utf-8")
             audit = {"ok": True, "facts": {"anima": {"imports": {"torch": True}}}}
@@ -161,8 +168,7 @@ class AnimaFastPluginApiTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             layout = ExtensionLayout(root / "extensions" / "anima_lora")
-            layout.source.mkdir(parents=True)
-            layout.train_py.write_text("", encoding="utf-8")
+            self._make_ready_source(layout)
             layout.venv_python.parent.mkdir(parents=True)
             layout.venv_python.write_text("", encoding="utf-8")
             write_install_state(layout, STATE_READY, {"audit": {"ok": True}})
@@ -181,8 +187,7 @@ class AnimaFastPluginApiTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             layout = ExtensionLayout(root / "extensions" / "anima_lora")
-            layout.source.mkdir(parents=True)
-            layout.train_py.write_text("", encoding="utf-8")
+            self._make_ready_source(layout)
             layout.venv_python.parent.mkdir(parents=True)
             layout.venv_python.write_text("", encoding="utf-8")
             write_install_state(layout, STATE_READY, {"audit": {"ok": True}})


### PR DESCRIPTION
## Summary
- treat Anima Fast `ready` state as broken when required runtime files are missing
- require `configs/base.toml` and `preprocess/resize_images.py` in addition to `train.py`
- update Fast plugin/API tests so ready fixtures include the required runtime shape

## Why
Follow-up to #148: the UI now hides install controls when the plugin is ready, but a stale/local `install_state.json` could still report `ready` while the copied runtime source was incomplete. In that case `/api/plugins/anima-lora/status` misled users and training failed later during dataset preparation.

## Tests
- `venv\\Scripts\\python.exe -m pytest tests/test_anima_fast_plugin_api.py tests/test_anima_fast_integration_static.py tests/test_anima_fast_environment_installer.py tests/test_install_anima_fast_cli.py tests/test_anima_fast_backend.py::ExtensionStateTests tests/test_anima_fast_preprocess.py -q`