### PR TITLE
fix(portable): validate requirements.txt on every launch (fixes tagger onnxruntime)

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -6,7 +6,8 @@ import subprocess
 import sys
 
 from mikazuki.launch_utils import (base_dir_path, catch_exception, git_tag,
-                                   prepare_environment, check_port_avaliable)
+                                   prepare_environment, check_port_avaliable,
+                                   ensure_requirements_installed)
 from mikazuki.log import log
 from mikazuki.portable_utils import sanitize_embedded_deps, train_env_overrides
 
@@ -128,6 +129,12 @@ def launch():
 
     if not args.skip_prepare_environment:
         prepare_environment(disable_auto_mirror=args.disable_auto_mirror)
+    else:
+        # Portable launch skips prepare_environment, so requirements.txt is
+        # otherwise never validated. Run a cheap presence-only guard so newly
+        # added or missing packages (e.g. onnxruntime-gpu) get repaired instead
+        # of silently breaking tagging/training.
+        ensure_requirements_installed("requirements.txt")
 
     # Protect each service's default port before scanning fallbacks. Otherwise
     # TensorBoard can claim 6008 as a fallback and make monitor links open it.

--- a/mikazuki/launch_utils.py
+++ b/mikazuki/launch_utils.py
@@ -235,6 +235,72 @@ def validate_requirements(requirements_file: str):
                     run_pip(f"install \"{spec}\"", spec, live=True)
 
 
+def ensure_requirements_installed(requirements_file: str = "requirements.txt") -> None:
+    """Lightweight presence-only requirements guard for portable launches.
+
+    The portable launcher starts gui.py with --skip-prepare-environment, which
+    bypasses prepare_environment() / validate_requirements(). As a result a
+    fresh-but-incomplete package (e.g. missing onnxruntime-gpu) never gets
+    repaired and tagging/training silently breaks. This runs on every launch,
+    is intentionally cheap (existence check only, no version pinning so it does
+    not fight pip's resolver), and installs only what is actually missing.
+    """
+    req_path = requirements_file
+    if not os.path.isabs(req_path):
+        req_path = str(base_dir_path() / requirements_file)
+    if not os.path.isfile(req_path):
+        return
+
+    try:
+        with open(req_path, "r", encoding="utf8") as f:
+            raw_lines = f.readlines()
+    except OSError as e:
+        log.warning(f"could not read {req_path}: {e}")
+        return
+
+    index_url = ""
+    missing: List[str] = []
+    for raw in raw_lines:
+        line = raw.strip()
+        if (
+            line == ""
+            or line.startswith("#")
+            or "# skip_verify" in line
+            or (line.startswith("-") and not line.startswith("--index-url "))
+        ):
+            continue
+        if line.startswith("--index-url "):
+            index_url = line.replace("--index-url ", "").strip()
+            continue
+
+        spec, marker_matches = _parse_env_marker(line)
+        if not marker_matches:
+            continue
+        # Strip inline comments and keep the bare requirement spec.
+        spec = spec.split("#", 1)[0].strip()
+        if not spec:
+            continue
+        # Presence-only: drop any version constraint so an already-installed
+        # (but differently versioned) package is not flagged as missing.
+        name_only = re.split(r"[<>=!~\[ ]", spec, 1)[0].strip()
+        if not name_only or is_installed(name_only):
+            continue
+        missing.append(spec)
+
+    if not missing:
+        return
+
+    log.info(f"detected missing requirements, installing: {', '.join(missing)}")
+    for spec in missing:
+        try:
+            if index_url:
+                run_pip(f'install "{spec}" --index-url {index_url}', spec, live=True)
+            else:
+                run_pip(f'install "{spec}"', spec, live=True)
+        except Exception as e:
+            log.error(f"failed to install missing requirement {spec}: {e}")
+
+
 def setup_windows_bitsandbytes():
     if sys.platform != "win32":
         return

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,8 @@ httpx==0.24.1
 open-clip-torch==2.20.0
 lycoris-lora==3.3.0
 dadaptation==3.1
+# tagger (WD14 etc.) — required by dataset tagging; NVIDIA portable build uses GPU build
+onnxruntime-gpu
 # triton for Windows — source installs only (portable package skips this)
 # Needed by flash-attn on Windows; portable package has prebuilt flash-attn wheel that bundles triton.
 triton-windows<3.4; sys_platform == "win32" # skip_verify

--- a/setup_environment.py
+++ b/setup_environment.py
@@ -119,8 +119,76 @@ def _separator():
 # ──────────────────── Core logic ────────────────────
 
 
-def check_already_installed():
-    """Return True only when core runtime deps are importable."""
+def _missing_requirements():
+    """Return requirement specs from requirements.txt that are not installed.
+
+    Uses the embedded interpreter's own pip metadata so the check matches what
+    install_requirements would actually install. Triton-windows is skipped to
+    stay consistent with _filter_requirements.
+    """
+    req_file = os.path.join(_sd_trainer_dir(), "requirements.txt")
+    if not os.path.isfile(req_file):
+        return []
+
+    check_src = (
+        "import sys\n"
+        "try:\n"
+        "    from importlib.metadata import distributions\n"
+        "except Exception:\n"
+        "    print('CHECK_UNAVAILABLE'); sys.exit(0)\n"
+        "import re\n"
+        "skip = {'triton-windows', 'triton'}\n"
+        "installed = set()\n"
+        "for dist in distributions():\n"
+        "    name = (dist.metadata['Name'] or '').strip().lower().replace('_', '-')\n"
+        "    if name:\n"
+        "        installed.add(name)\n"
+        "missing = []\n"
+        "with open(sys.argv[1], 'r', encoding='utf-8') as f:\n"
+        "    for raw in f:\n"
+        "        line = raw.strip()\n"
+        "        if not line or line.startswith('#') or line.startswith('-'):\n"
+        "            continue\n"
+        "        if '# skip_verify' in line:\n"
+        "            continue\n"
+        "        spec = line.split('#', 1)[0].strip()\n"
+        "        if ';' in spec:\n"
+        "            cond = spec.split(';', 1)[1]\n"
+        "            if 'win32' in cond and sys.platform != 'win32':\n"
+        "                continue\n"
+        "            if 'linux' in cond and sys.platform != 'linux':\n"
+        "                continue\n"
+        "            spec = spec.split(';', 1)[0].strip()\n"
+        "        name = re.split(r'[<>=!~\\[ ]', spec, 1)[0].strip().lower().replace('_', '-')\n"
+        "        if not name or name in skip:\n"
+        "            continue\n"
+        "        if name not in installed:\n"
+        "            missing.append(name)\n"
+        "for m in missing:\n"
+        "    print(m)\n"
+    )
+    try:
+        result = subprocess.run(
+            [_python_exe(), "-s", "-c", check_src, req_file],
+            capture_output=True, text=True, timeout=60,
+            env={**os.environ, "PYTHONNOUSERSITE": "1"},
+        )
+    except Exception:
+        return []
+    out = (result.stdout or "").strip()
+    if not out or "CHECK_UNAVAILABLE" in out:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def check_already_installed(quiet=False):
+    """Return True only when core runtime deps are importable AND every
+    requirements.txt package is present. A missing requirement (e.g. a newly
+    added onnxruntime-gpu after an update) triggers the repair install path."""
+    def _say(msg):
+        if not quiet:
+            print(msg)
+
     torch_dir = os.path.join(
         _base_dir(), "python_embeded", "Lib", "site-packages", "torch"
     )
@@ -132,8 +200,14 @@ def check_already_installed():
         try:
             __import__(module)
         except Exception as exc:
-            print(f"  检测到依赖不完整，将执行修复安装：{module} ({exc})")
+            _say(f"  检测到依赖不完整，将执行修复安装：{module} ({exc})")
             return False
+
+    missing = _missing_requirements()
+    if missing:
+        preview = ", ".join(missing[:8]) + (" ..." if len(missing) > 8 else "")
+        _say(f"  检测到缺失的依赖，将执行补装：{preview}")
+        return False
 
     return True
 
@@ -358,12 +432,49 @@ def verify_installation():
 # ──────────────────── Main ────────────────────
 
 
+def _core_modules_ok():
+    torch_dir = os.path.join(
+        _base_dir(), "python_embeded", "Lib", "site-packages", "torch"
+    )
+    if not os.path.isdir(torch_dir):
+        return False
+    for module in ("torch", "torchvision", "accelerate", "diffusers", "gradio"):
+        try:
+            __import__(module)
+        except Exception:
+            return False
+    return True
+
+
+def repair_requirements_only():
+    """Fast path: core/PyTorch already present, only requirements.txt has
+    new/missing packages (e.g. onnxruntime-gpu added by an update). Install
+    just the requirements without re-probing/re-downloading PyTorch."""
+    _banner()
+    region = detect_network()
+    if region == "china":
+        print("  检测到缺失依赖，使用国内镜像补装训练组件...")
+    else:
+        print("  检测到缺失依赖，补装训练组件...")
+    write_mirror_env(region)
+    if not install_requirements(region):
+        _fail("依赖补装失败，请检查网络连接后重新运行 run_gui.bat")
+        return 1
+    _ok("依赖补装完成")
+    return 0
+
+
 def main():
     _banner()
 
     if check_already_installed():
         print("  环境已安装，跳过安装步骤。")
         return 0
+
+    # Lightweight repair: PyTorch + core deps are fine, only some
+    # requirements.txt packages are missing. Avoid the full ~3GB PyTorch path.
+    if _core_modules_ok() and _missing_requirements():
+        return repair_requirements_only()
 
     # GPU check — warn AMD users early
     gpu = detect_gpu()


### PR DESCRIPTION
## 背景

整合包启动时**从不读取 `requirements.txt`**，这是打标器反复失效的根本原因。

`launch_portable.bat` 用 `gui.py --skip-prepare-environment` 启动，而只有 `prepare_environment()` 里才有读取 `requirements.txt` 的 `validate_requirements()`。便携包跳过了它，于是：

- `requirements.txt` 在便携启动全程没被读取过；
- `onnxruntime` 又不在 `requirements.txt` 里，只靠运行时 `setup_onnxruntime()` 按需补装，而这一步也被便携包跳过；
- 结果：即使整合包自带完整的打标模型（`tagger-models/.../model.onnx` ~379MB），WD14 打标仍在 `Loading ... model` 处失败，报 `No module named 'onnxruntime'`。

已在 `SD-Trainer-v2.8.0-beta.1` 整合包现场复现：`onnxruntime` 确实未安装；手动 `pip install onnxruntime-gpu` 后，用包内 Python 加载自带 `model.onnx` 成功，CUDA EP 正常激活。

## 改动

- **`requirements.txt`**：加入 `onnxruntime-gpu`，把打标依赖纳入锁定清单。
- **`gui.py`**：即使 `--skip-prepare-environment`，启动时也运行一次轻量 requirements 校验，缺包即补装，而不是静默失败。
- **`mikazuki/launch_utils.py`**：新增 `ensure_requirements_installed()` —— 仅校验「包是否存在」（不锁版本，避免与 pip 解析器冲突），正确处理 `# skip_verify`、平台 marker、`--index-url`、行内注释。
- **`setup_environment.py`**：首次安装/修复流程也校验 `requirements.txt`，并支持「只缺普通依赖时」的轻量补装路径（不重跑 ~3GB 的 PyTorch 下载）。

## 覆盖路径

- 源码启动：`prepare_environment() → validate_requirements()`（原有逻辑）。
- 整合包 / AutoDL：`--skip-prepare-environment` 分支 → `ensure_requirements_installed()`（本次新增）。

两条路径都不会再漏读 `requirements.txt`。onnxruntime 只是第一个暴露的症状，此修复对后续任何新增/缺失依赖同样生效。

## 验证

- 用 `SD-Trainer-v2.8.0-beta.1` 整合包内 Python 实测：补装 onnxruntime-gpu 后检测结果为「无缺失」，**不会误触发重装**已装包；不存在的包能被正确检出为缺失。
- 版本约束被正确剥离（presence-only），已装但版本不同的包不会被误判。
- 三个文件语法、lint 全部通过。

Refs #147 #106 #151
