### PR TITLE
fix(portable): allow flash-attn on embedded Python when stack is usable

### DIFF
--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -68,7 +68,7 @@ from mikazuki.train_log_hub import hub as train_log_hub
 from mikazuki.utils import train_utils
 from mikazuki.utils.config_import import validate_config_import
 from mikazuki.utils.devices import printable_devices
-from mikazuki.portable_utils import flash_attn_stack_usable, is_embedded_python
+from mikazuki.portable_utils import flash_attn_stack_usable
 from mikazuki.utils.tk_window import (open_directory_selector,
                                       open_file_selector,
                                       tkinter_available)
@@ -366,7 +366,7 @@ def should_generate_sample_prompts(config: dict) -> bool:
 
 def _detect_best_attn_mode() -> str:
     """Auto-detect the best available attention backend for Anima training."""
-    if not is_embedded_python() and flash_attn_stack_usable():
+    if flash_attn_stack_usable():
         return "flash"
     try:
         import xformers  # noqa: F401
@@ -553,7 +553,7 @@ def apply_anima_training_defaults(config: dict, model_train_type: str):
                 f"falling back to '{best}'"
             )
     elif requested_attn == "flash":
-        if is_embedded_python() or not flash_attn_stack_usable():
+        if not flash_attn_stack_usable():
             best = _detect_best_attn_mode()
             config["attn_mode"] = best
             log.warning(

--- a/mikazuki/portable_utils.py
+++ b/mikazuki/portable_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Helpers for Windows portable (embedded) Python — flash-attn needs triton, which does not work reliably here."""
+"""Helpers for Windows portable (embedded) Python — flash-attn/triton compatibility."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ def is_embedded_python(executable: Optional[str] = None) -> bool:
 
 
 def flash_attn_stack_usable() -> bool:
-    """True only when flash-attn and its triton ops import cleanly (not true on embedded Python)."""
+    """True when flash-attn and its triton ops import cleanly in the current interpreter."""
     try:
         import triton  # noqa: F401
         import flash_attn  # noqa: F401
@@ -69,7 +69,8 @@ def train_env_overrides() -> Dict[str, str]:
     """Environment for training subprocesses on embedded Python."""
     if not is_embedded_python():
         return {}
-    return {
-        "TRANSFORMERS_ATTN_IMPLEMENTATION": "sdpa",
-        "XFORMERS_FORCE_DISABLE_TRITON": "1",
-    }
+
+    overrides: Dict[str, str] = {"XFORMERS_FORCE_DISABLE_TRITON": "1"}
+    if not flash_attn_stack_usable():
+        overrides["TRANSFORMERS_ATTN_IMPLEMENTATION"] = "sdpa"
+    return overrides

--- a/tests/test_portable_utils_flash_attn.py
+++ b/tests/test_portable_utils_flash_attn.py
@@ -1,0 +1,44 @@
+import sys
+import types
+
+import pytest
+
+from mikazuki.app.api import _detect_best_attn_mode
+from mikazuki.portable_utils import train_env_overrides
+
+
+def test_detect_best_attn_mode_prefers_flash_when_stack_usable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("mikazuki.app.api.flash_attn_stack_usable", lambda: True)
+    assert _detect_best_attn_mode() == "flash"
+
+
+def test_detect_best_attn_mode_uses_xformers_without_flash(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("mikazuki.app.api.flash_attn_stack_usable", lambda: False)
+    monkeypatch.setitem(sys.modules, "xformers", types.ModuleType("xformers"))
+    assert _detect_best_attn_mode() == "xformers"
+
+
+def test_detect_best_attn_mode_uses_torch_without_flash_or_xformers(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("mikazuki.app.api.flash_attn_stack_usable", lambda: False)
+    monkeypatch.delitem(sys.modules, "xformers", raising=False)
+    assert _detect_best_attn_mode() == "torch"
+
+
+def test_train_env_overrides_skips_sdpa_when_flash_usable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("mikazuki.portable_utils.is_embedded_python", lambda executable=None: True)
+    monkeypatch.setattr("mikazuki.portable_utils.flash_attn_stack_usable", lambda: True)
+    assert train_env_overrides() == {"XFORMERS_FORCE_DISABLE_TRITON": "1"}
+
+
+def test_train_env_overrides_sets_sdpa_when_flash_unusable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("mikazuki.portable_utils.is_embedded_python", lambda executable=None: True)
+    monkeypatch.setattr("mikazuki.portable_utils.flash_attn_stack_usable", lambda: False)
+    assert train_env_overrides() == {
+        "XFORMERS_FORCE_DISABLE_TRITON": "1",
+        "TRANSFORMERS_ATTN_IMPLEMENTATION": "sdpa",
+    }
+
+
+def test_train_env_overrides_empty_on_non_embedded(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("mikazuki.portable_utils.is_embedded_python", lambda executable=None: False)
+    assert train_env_overrides() == {}


### PR DESCRIPTION
## Summary

- Remove blanket `is_embedded_python()` exclusion from Anima `attn_mode=flash` detection; rely on `flash_attn_stack_usable()` instead.
- In portable training subprocess env, only force `TRANSFORMERS_ATTN_IMPLEMENTATION=sdpa` when flash-attn/triton stack is not usable.
- Add unit tests for attn auto-detection and `train_env_overrides()`.

## Test plan

- [x] `pytest tests/test_portable_utils_flash_attn.py`
- [ ] On embedded Python with prebuilt flash-attn + triton wheels: `attn_mode=flash` stays flash and no SDPA override in train env
- [ ] On embedded Python without flash stack: still falls back to xformers/torch with SDPA override

Fixes #152
