### PR TITLE
fix(anima-fast): clamp preview sample schedule for short epoch runs

### DIFF
--- a/mikazuki/anima_fast_backend/preview.py
+++ b/mikazuki/anima_fast_backend/preview.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import os
 import random
 
-from .adapter import AdapterError, is_empty
+from .adapter import AdapterError, int_value, is_empty
 from mikazuki.utils.train_utils import build_sample_prompt_line as build_kohya_sample_prompt_line
 
 DEFAULT_SAMPLE_POSITIVE = (
@@ -89,6 +89,35 @@ def build_sample_prompt_line(config: dict) -> str:
     )
 
 
+def _normalize_sample_schedule(config: dict, warnings: list[str]) -> None:
+    """Clamp epoch-based sampling so preview can fire before training ends."""
+    if not is_empty(config.get("sample_every_n_steps")):
+        return
+
+    max_epochs = int_value(config.get("max_train_epochs"), 0)
+    if max_epochs <= 0:
+        if is_empty(config.get("sample_every_n_epochs")):
+            config["sample_every_n_epochs"] = 2
+        return
+
+    if is_empty(config.get("sample_every_n_epochs")):
+        config["sample_every_n_epochs"] = min(2, max_epochs)
+        return
+
+    every_epochs = int_value(config.get("sample_every_n_epochs"), 0)
+    if every_epochs <= 0:
+        config["sample_every_n_epochs"] = min(2, max_epochs)
+        return
+
+    if every_epochs > max_epochs:
+        original = every_epochs
+        config["sample_every_n_epochs"] = max_epochs
+        warnings.append(
+            f"sample_every_n_epochs 已从 {original} 调整为 {max_epochs} "
+            f"（不超过 max_train_epochs={max_epochs}，否则训练结束前不会生成预览图）"
+        )
+
+
 def apply_anima_fast_preview(config: dict, autosave_dir: str, run_id: str) -> list[str]:
     warnings: list[str] = []
     if not is_preview_enabled(config):
@@ -115,8 +144,7 @@ def apply_anima_fast_preview(config: dict, autosave_dir: str, run_id: str) -> li
 
     if config.get("sample_at_first") is None:
         config["sample_at_first"] = False
-    if is_empty(config.get("sample_every_n_epochs")) and is_empty(config.get("sample_every_n_steps")):
-        config["sample_every_n_epochs"] = 2
+    _normalize_sample_schedule(config, warnings)
     config.setdefault("sample_sampler", "euler")
 
     warnings.append(

--- a/tests/test_anima_fast_preview.py
+++ b/tests/test_anima_fast_preview.py
@@ -171,6 +171,49 @@ class AnimaFastPreviewTests(unittest.TestCase):
         self.assertTrue(is_preview_enabled({"enable_preview": "true"}))
         self.assertFalse(is_preview_enabled({"enable_preview": False}))
 
+    def test_sample_every_n_epochs_clamped_to_max_train_epochs(self):
+        config = {
+            "enable_preview": True,
+            "max_train_epochs": 1,
+            "sample_every_n_epochs": 2,
+            "positive_prompts": "1girl",
+        }
+        warnings = apply_anima_fast_preview(config, "/tmp/autosave", "run-clamp")
+        self.assertEqual(config["sample_every_n_epochs"], 1)
+        self.assertFalse(config.get("sample_at_first"))
+        self.assertTrue(any("sample_every_n_epochs" in item for item in warnings))
+
+    def test_sample_every_n_epochs_unchanged_when_within_max_epochs(self):
+        config = {
+            "enable_preview": True,
+            "max_train_epochs": 3,
+            "sample_every_n_epochs": 2,
+            "positive_prompts": "1girl",
+        }
+        warnings = apply_anima_fast_preview(config, "/tmp/autosave", "run-ok")
+        self.assertEqual(config["sample_every_n_epochs"], 2)
+        self.assertFalse(any("已从 2 调整为" in item for item in warnings))
+
+    def test_sample_schedule_skipped_when_sampling_by_steps(self):
+        config = {
+            "enable_preview": True,
+            "max_train_epochs": 1,
+            "sample_every_n_epochs": 2,
+            "sample_every_n_steps": 100,
+            "positive_prompts": "1girl",
+        }
+        apply_anima_fast_preview(config, "/tmp/autosave", "run-steps")
+        self.assertEqual(config["sample_every_n_epochs"], 2)
+
+    def test_default_sample_every_n_epochs_respects_single_epoch_run(self):
+        config = {
+            "enable_preview": True,
+            "max_train_epochs": 1,
+            "positive_prompts": "1girl",
+        }
+        apply_anima_fast_preview(config, "/tmp/autosave", "run-default")
+        self.assertEqual(config["sample_every_n_epochs"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Clamp `sample_every_n_epochs` to `max_train_epochs` in `apply_anima_fast_preview()` when preview is enabled, so short Fast runs (e.g. 1 epoch + every 2 epochs) still produce at least one sample before training ends.
- Default unset `sample_every_n_epochs` to `min(2, max_train_epochs)` instead of always `2`.
- Skip normalization when `sample_every_n_steps` is set (step-based sampling unchanged).
- Does **not** auto-enable `sample_at_first` (conservative).

## Test plan

- [x] `pytest tests/test_anima_fast_preview.py`
- [ ] Fast 1-epoch run with preview enabled → `output_dir/sample/` gets images
- [ ] 3-epoch run with `sample_every_n_epochs=2` → unchanged behavior

Refs #126 (issue kept open for broader preview UX follow-up)
