### PR TITLE
fix(train): inject project root onto PYTHONPATH for training subprocess (#158)

### DIFF
--- a/mikazuki/process.py
+++ b/mikazuki/process.py
@@ -90,6 +90,18 @@ def build_accelerate_train_command(
 
     customize_env = os.environ.copy()
     customize_env.update(train_env_overrides())
+    # The training subprocess runs ``python mikazuki/accelerate_launch.py``,
+    # whose entry imports ``mikazuki.china_hub``. Launching by script path puts
+    # only the script's own directory (``mikazuki/``) on sys.path, not the
+    # project root, so portable installs (no editable/site-packages mikazuki)
+    # fail with ``ModuleNotFoundError: No module named 'mikazuki'`` (issue #158).
+    # Inject the project root onto PYTHONPATH so the package is importable.
+    project_root = str(base_dir_path())
+    existing_pythonpath = customize_env.get("PYTHONPATH", "")
+    path_parts = [p for p in existing_pythonpath.split(os.pathsep) if p]
+    if project_root not in path_parts:
+        path_parts.insert(0, project_root)
+    customize_env["PYTHONPATH"] = os.pathsep.join(path_parts)
     customize_env["ACCELERATE_DISABLE_RICH"] = "1"
     customize_env["PYTHONUNBUFFERED"] = "1"
     customize_env["PYTHONWARNINGS"] = "ignore::FutureWarning,ignore::UserWarning"

--- a/tests/test_process_mixed_precision_launch.py
+++ b/tests/test_process_mixed_precision_launch.py
@@ -68,7 +68,7 @@ def _install_stub_modules() -> None:
     sys.modules["mikazuki.tasks"] = tasks_mod
 
     launch_mod = types.ModuleType("mikazuki.launch_utils")
-    launch_mod.base_dir_path = lambda: "."
+    launch_mod.base_dir_path = lambda: Path("/project/root")
     sys.modules["mikazuki.launch_utils"] = launch_mod
 
     portable_mod = types.ModuleType("mikazuki.portable_utils")
@@ -180,6 +180,41 @@ class BuildAccelerateTrainCommandTests(unittest.TestCase):
         self.assertEqual(env["NO_COLOR"], "1")
         self.assertEqual(env["FORCE_COLOR"], "0")
         self.assertEqual(env["TERM"], "dumb")
+
+    def test_injects_project_root_onto_pythonpath(self):
+        """Regression for #158: accelerate_launch.py imports mikazuki, so the
+        project root must be on PYTHONPATH for portable installs."""
+        with tempfile.TemporaryDirectory() as tmp:
+            toml_path = Path(tmp) / "train.toml"
+            toml_path.write_text('mixed_precision = "bf16"\n', encoding="utf-8")
+            with mock.patch.dict("os.environ", {}, clear=False):
+                import os
+
+                os.environ.pop("PYTHONPATH", None)
+                _args, env, _mp = process.build_accelerate_train_command(
+                    trainer_file="./scripts/stable/train_network.py",
+                    toml_path=str(toml_path),
+                )
+
+        self.assertEqual(env["PYTHONPATH"], str(Path("/project/root")))
+
+    def test_prepends_project_root_preserving_existing_pythonpath(self):
+        import os
+
+        existing = os.pathsep.join(["/already/here", "/second"])
+        with tempfile.TemporaryDirectory() as tmp:
+            toml_path = Path(tmp) / "train.toml"
+            toml_path.write_text('mixed_precision = "bf16"\n', encoding="utf-8")
+            with mock.patch.dict("os.environ", {"PYTHONPATH": existing}, clear=False):
+                _args, env, _mp = process.build_accelerate_train_command(
+                    trainer_file="./scripts/stable/train_network.py",
+                    toml_path=str(toml_path),
+                )
+
+        parts = env["PYTHONPATH"].split(os.pathsep)
+        self.assertEqual(parts[0], str(Path("/project/root")))
+        self.assertIn("/already/here", parts)
+        self.assertIn("/second", parts)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

修复 #158：v2.8.0 整合包启动任意标准训练（LoKr / LoRA / SDXL 等）都会立即崩溃：

```
Traceback (most recent call last):
  File ".../mikazuki/accelerate_launch.py", line 7, in <module>
    from mikazuki.china_hub import enable_china_hub
ModuleNotFoundError: No module named 'mikazuki'
05:55:10 ERROR Training failed / 训练失败 (exit 1)
```

## 根因（#154 引入的回归）

#154 为了让训练子进程也启用 ModelScope 下载路由，新增了入口脚本 `mikazuki/accelerate_launch.py`，并把训练子进程的启动方式从：

```python
python -m accelerate.commands.launch ...
```

改为：

```python
python <project>/mikazuki/accelerate_launch.py ...
```

两种方式对 `sys.path` 的处理不同：

| 启动方式 | Python 自动加入 `sys.path[0]` |
|---|---|
| `-m 模块`（旧）| 当前工作目录（训练时为项目根）|
| 脚本路径（新）| **脚本所在目录 `mikazuki/`**，而非项目根 |

新方式下 `sys.path` 只有 `mikazuki/` 子目录，导入 `mikazuki` 包需要其**父目录（项目根）**在路径上，因此 `from mikazuki.china_hub import ...` 抛 `ModuleNotFoundError`。子进程 env 是裸 `os.environ.copy()`，未注入 `PYTHONPATH`，便携包（`mikazuki` 未装进 site-packages）必崩。

> 开发机 / 旧版未暴露：开发环境通常把 `mikazuki` 装进 site-packages（任意 cwd 可导入），掩盖了该问题；#154 的单测在进程内直接 import，未真正起子进程跑脚本路径。

## 改动

`mikazuki/process.py` `build_accelerate_train_command`：将项目根（`base_dir_path()`）前插到子进程 `PYTHONPATH`，保留已有 `PYTHONPATH`，恢复旧启动方式的等价行为，同时保留 #154 的 ModelScope 钩子入口。

## 测试

`tests/test_process_mixed_precision_launch.py` 新增 2 个回归用例：

- `test_injects_project_root_onto_pythonpath`
- `test_prepends_project_root_preserving_existing_pythonpath`

```
python -m unittest tests.test_process_mixed_precision_launch  # 8 passed
```

另实测：设 `PYTHONPATH=<项目根>` 后，从非项目根 cwd 运行 `accelerate_launch.py`，`from mikazuki.china_hub import ...` 不再报错。

Fixes #158
