### PR TITLE
fix(anima-fast): 开启预览后 sample_at_first 默认 true，确保至少出一张图 (#126)

### DIFF
--- a/mikazuki/anima_fast_backend/preview.py
+++ b/mikazuki/anima_fast_backend/preview.py
@@ -143,7 +143,11 @@ def apply_anima_fast_preview(config: dict, autosave_dir: str, run_id: str) -> li
         config["sample_prompts"] = str(out_path.resolve())
 
     if config.get("sample_at_first") is None:
-        config["sample_at_first"] = False
+        # Default to sampling once at training start so an enabled preview
+        # always produces at least one image, even for short/epoch-clamped runs
+        # (regression from 7cb49dc, reported in #126). Users can still set it
+        # to False explicitly to skip the step-0 sample and lower VRAM peak.
+        config["sample_at_first"] = True
     _normalize_sample_schedule(config, warnings)
     config.setdefault("sample_sampler", "euler")
 

--- a/mikazuki/schema/anima-lora-fast.ts
+++ b/mikazuki/schema/anima-lora-fast.ts
@@ -70,7 +70,7 @@ Schema.intersect([
                 sample_seed: Schema.number().default(42).description("预览图种子"),
                 sample_steps: Schema.number().min(1).max(300).default(40).description("推理步数（Anima 建议 30–50）"),
                 sample_sampler: Schema.union(["euler", "k_euler"]).default("euler").description("Anima 训练预览采样器"),
-                sample_at_first: Schema.boolean().default(false).description("训练开始前生成 step 0 预览图。默认关闭；开启会在训练前额外采样一次并增加显存峰值"),
+                sample_at_first: Schema.boolean().default(true).description("训练开始前生成 step 0 预览图。默认开启，确保启用预览后至少能看到一张图；关闭可省去训练前的一次采样、降低显存峰值"),
                 sample_every_n_epochs: Schema.number().default(2).description("每 N 个 epoch 生成一次预览图"),
             }),
             Schema.object({}),

--- a/tests/test_anima_fast_preview.py
+++ b/tests/test_anima_fast_preview.py
@@ -75,7 +75,7 @@ class AnimaFastPreviewTests(unittest.TestCase):
             adapted = adapt_config(config, runtime, run_id)
             self.assertIn("sample_prompts", adapted.values)
             self.assertEqual(adapted.values["sample_every_n_epochs"], 1)
-            self.assertFalse(adapted.values["sample_at_first"])
+            self.assertTrue(adapted.values["sample_at_first"])
             self.assertNotIn("enable_preview", adapted.values)
             self.assertNotIn("positive_prompts", adapted.values)
 
@@ -180,7 +180,7 @@ class AnimaFastPreviewTests(unittest.TestCase):
         }
         warnings = apply_anima_fast_preview(config, "/tmp/autosave", "run-clamp")
         self.assertEqual(config["sample_every_n_epochs"], 1)
-        self.assertFalse(config.get("sample_at_first"))
+        self.assertTrue(config.get("sample_at_first"))
         self.assertTrue(any("sample_every_n_epochs" in item for item in warnings))
 
     def test_sample_every_n_epochs_unchanged_when_within_max_epochs(self):
@@ -213,6 +213,31 @@ class AnimaFastPreviewTests(unittest.TestCase):
         }
         apply_anima_fast_preview(config, "/tmp/autosave", "run-default")
         self.assertEqual(config["sample_every_n_epochs"], 1)
+
+    def test_sample_at_first_defaults_true_so_preview_always_fires(self):
+        """Regression for #126: preview enabled must produce at least one image.
+
+        7cb49dc flipped the implicit sample_at_first default to False, so short
+        or epoch-clamped runs could finish without ever sampling. Default back
+        to True when the user did not set it explicitly.
+        """
+        config = {
+            "enable_preview": True,
+            "max_train_epochs": 1,
+            "positive_prompts": "1girl",
+        }
+        apply_anima_fast_preview(config, "/tmp/autosave", "run-at-first")
+        self.assertTrue(config["sample_at_first"])
+
+    def test_explicit_sample_at_first_false_is_preserved(self):
+        config = {
+            "enable_preview": True,
+            "max_train_epochs": 4,
+            "positive_prompts": "1girl",
+            "sample_at_first": False,
+        }
+        apply_anima_fast_preview(config, "/tmp/autosave", "run-explicit-false")
+        self.assertFalse(config["sample_at_first"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

修复 #126：Fast 模式开启「训练预览图」后，部分场景（轮数很少 / epoch 被钳制）训练全程不出预览图。

## 根因

`7cb49dc` 把 `apply_anima_fast_preview` 中 `sample_at_first` 的隐式默认从「未设置时采样」改成了 `False`。当用户开启预览但没显式设 `sample_at_first`，且训练轮数过短或 `sample_every_n_epochs` 被钳制时，整轮训练可能在任何一次 epoch 采样触发前就结束，导致 `output_dir/sample/` 始终为空——用户感知就是「开了预览却没图」。

## 改动

- `mikazuki/anima_fast_backend/preview.py`：当 `sample_at_first` 未显式设置时默认回 `True`，确保启用预览后至少在 step 0 出一张图。显式设 `False` 的用户行为保持不变（仍可跳过 step-0 采样、降低显存峰值）。
- `mikazuki/schema/anima-lora-fast.ts`：schema 默认值 `false → true`，并更新描述。
- `tests/test_anima_fast_preview.py`：
  - 修正受影响的既有断言（默认值翻转）。
  - 新增两条回归测试：默认开启时 step-0 必采样；显式 `False` 被保留。

## 测试

### 单元测试

`python -m unittest tests.test_anima_fast_preview` —— 16 项全过，含两条新回归用例。

### 端到端命令行验证（实卡）

用一个小样本数据集（10 张图 + caption）做了完整 Fast 训练（2 epoch、实时 VAE 编码、关闭 torch_compile），日志确认 step 0 触发采样：

```
INFO  Generating sample images at step 0   training.py:852
  prompt: 1girl, solo, black hair, school uniform, red ribbon, upper body, ...
Sampling: 100%|██████████| 20/20
```

`output_dir/sample/` 最终落盘 3 张预览图：

| 文件后缀 | 时机 | 含义 |
|---|---|---|
| `_e000000_...png` | step 0 / 训练前 | `sample_at_first=true` 生效 |
| `_e000001_...png` | epoch 1 后 | 周期采样 |
| `_e000002_...png` | epoch 2 后 | 训练结束 |

step 0 那张为完整正常的动漫角色图（与 prompt 吻合），确认非黑图、非空跑。LoRA 权重也正常保存。

## 影响面

- 仅影响 Fast 模式预览图的默认行为，不改训练主流程。
- 默认值翻转后，开启预览会在训练前多采样一次（额外少量显存/时间）；显式关闭可恢复旧行为。
