### PR TITLE
fix(anima): guard LoKr bf16 weight decomposition

### DIFF
--- a/mikazuki/anima_backend/adapter.py
+++ b/mikazuki/anima_backend/adapter.py
@@ -197,6 +197,15 @@ LOKR_TRAIN_NORM_WARNING = (
     "LyCORIS train_norm is disabled for Anima LoKr because LyCORIS NormModule "
     "can crash on Anima norm layers without affine weights during preview sampling."
 )
+LOKR_BF16_WEIGHT_DECOMPOSITION_WARNING = (
+    "LyCORIS LoKr weight decomposition is disabled for Anima mixed_precision=bf16 "
+    "because some LyCORIS versions keep an unsafe dtype conversion path for "
+    "dora_wd/weight_decomposition."
+)
+LOKR_FULL_MATRIX_WARNING = (
+    "Anima LoKr full_matrix=true uses conservative stability guardrails: "
+    "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1."
+)
 
 
 def _is_empty_value(value: Any) -> bool:
@@ -268,6 +277,19 @@ def _network_args_use_lokr(network_args: list[str]) -> bool:
     return False
 
 
+def _network_args_has_truthy_arg(network_args: list[str], arg_key: str) -> bool:
+    target = arg_key.strip().lower()
+    for item in network_args:
+        if not isinstance(item, str) or "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        if key.strip().lower() != target:
+            continue
+        if str(value).strip().lower() in {"1", "true", "yes", "on"}:
+            return True
+    return False
+
+
 def _strip_arg(network_args: list[str], arg_key: str) -> tuple[list[str], bool]:
     stripped: list[str] = []
     removed = False
@@ -279,6 +301,16 @@ def _strip_arg(network_args: list[str], arg_key: str) -> tuple[list[str], bool]:
                 removed = True
                 continue
         stripped.append(item)
+    return stripped, removed
+
+
+def _strip_args(network_args: list[str], arg_keys: set[str]) -> tuple[list[str], list[str]]:
+    stripped = list(network_args)
+    removed: list[str] = []
+    for arg_key in arg_keys:
+        stripped, did_remove = _strip_arg(stripped, arg_key)
+        if did_remove:
+            removed.append(arg_key)
     return stripped, removed
 
 
@@ -342,6 +374,24 @@ def adapt_anima_config(
             network_args, removed_train_norm = _strip_arg(network_args, "train_norm")
             if removed_train_norm:
                 warnings.append(LOKR_TRAIN_NORM_WARNING)
+            if _network_args_has_truthy_arg(network_args, "full_matrix"):
+                disabled = []
+                for precision_key in ("full_bf16", "full_fp16"):
+                    if source.pop(precision_key, None):
+                        disabled.append(precision_key)
+                if _is_empty_value(source.get("scale_weight_norms")):
+                    source["scale_weight_norms"] = 1
+                if disabled:
+                    warnings.append(
+                        f"{LOKR_FULL_MATRIX_WARNING} Disabled full half precision: {', '.join(disabled)}"
+                    )
+            if str(source.get("mixed_precision", "")).strip().lower() == "bf16":
+                network_args, removed_weight_decomposition = _strip_args(
+                    network_args,
+                    {"dora_wd", "weight_decomposition"},
+                )
+                if removed_weight_decomposition:
+                    warnings.append(LOKR_BF16_WEIGHT_DECOMPOSITION_WARNING)
         if network_args:
             source["network_args"] = network_args
 

--- a/tests/test_anima_backend_adapter.py
+++ b/tests/test_anima_backend_adapter.py
@@ -208,6 +208,59 @@ class AnimaBackendAdapterTests(unittest.TestCase):
         self.assertNotIn("train_norm=True", adapted["network_args"])
         self.assertTrue(any("train_norm" in warning and "LoKr" in warning for warning in warnings))
 
+    def test_lokr_bf16_disables_weight_decomposition_args(self):
+        config = {
+            "network_module": "lycoris.kohya",
+            "lycoris_algo": "lokr",
+            "mixed_precision": "bf16",
+            "full_bf16": True,
+            "full_matrix": True,
+            "dora_wd": True,
+            "network_args": ["factor=-1", "weight_decomposition=True"],
+        }
+
+        adapted, warnings = adapt_anima_config(config)
+
+        self.assertIn("network_args", adapted)
+        self.assertIn("algo=lokr", adapted["network_args"])
+        self.assertIn("factor=-1", adapted["network_args"])
+        self.assertIn("full_matrix=True", adapted["network_args"])
+        self.assertNotIn("dora_wd=True", adapted["network_args"])
+        self.assertNotIn("weight_decomposition=True", adapted["network_args"])
+        self.assertTrue(
+            any("weight decomposition" in warning and "mixed_precision=bf16" in warning for warning in warnings)
+        )
+
+    def test_lokr_full_matrix_disables_full_half_precision_in_adapter(self):
+        config = {
+            "network_module": "lycoris.kohya",
+            "lycoris_algo": "lokr",
+            "mixed_precision": "bf16",
+            "full_bf16": True,
+            "full_matrix": True,
+        }
+
+        adapted, warnings = adapt_anima_config(config)
+
+        self.assertIn("full_matrix=True", adapted["network_args"])
+        self.assertNotIn("full_bf16", adapted)
+        self.assertEqual(adapted["scale_weight_norms"], 1)
+        self.assertTrue(any("full_matrix=true" in warning for warning in warnings))
+
+    def test_lokr_fp16_keeps_weight_decomposition_args(self):
+        config = {
+            "network_module": "lycoris.kohya",
+            "lycoris_algo": "lokr",
+            "mixed_precision": "fp16",
+            "dora_wd": True,
+            "network_args": ["weight_decomposition=True"],
+        }
+
+        adapted, warnings = adapt_anima_config(config)
+
+        self.assertIn("dora_wd=True", adapted["network_args"])
+        self.assertIn("weight_decomposition=True", adapted["network_args"])
+
     def test_lycoris_non_lokr_keeps_train_norm(self):
         config = {
             "network_module": "lycoris.kohya",


### PR DESCRIPTION
## Summary
- Guard Anima LoKr bf16 configs before they reach the training backend: `dora_wd` / `weight_decomposition` is stripped when `mixed_precision=bf16`.
- Keep `full_matrix=true` LoKr configs on the conservative fp32 adapter path by removing `full_bf16/full_fp16` and defaulting `scale_weight_norms=1`.
- Add adapter coverage for bf16 DoRA stripping, full_matrix precision guardrails, and fp16 preservation.

## Why
LyCORIS upstream still has an unsafe DoRA / Weight Decomposition dtype path for bf16 LoKr training. Current upstream code can promote the decomposed weight path through fp32 `dora_scale`, which can conflict with bf16 activations during training.

This is not something SD Trainer Next can reliably fix inside the training script without forking or monkey-patching LyCORIS internals. The safest project-side behavior is to reject/sanitize the incompatible option combination before launching training, so users can still train LoKr in bf16 without hitting the upstream DoRA crash path.

## Test plan
- `python -m pytest tests/test_anima_backend_adapter.py tests/test_anima_training_defaults.py tests/test_anima_train_wrapper.py`
- `python -m pytest tests/test_standard_run_api.py tests/test_process_mixed_precision_launch.py tests/test_process_train_log_url.py tests/test_tokenizer_cache.py tests/test_train_routing.py tests/test_anima_backend_adapter.py tests/test_anima_training_defaults.py tests/test_anima_train_wrapper.py`