### PR TITLE
fix(train): allow user site training dependencies

### DIFF
--- a/mikazuki/process.py
+++ b/mikazuki/process.py
@@ -1,6 +1,8 @@
 
 import asyncio
+import importlib.util
 import os
+import site
 import sys
 import webbrowser
 import uuid
@@ -61,6 +63,38 @@ def read_mixed_precision_from_train_toml(toml_path: str) -> Optional[str]:
     return normalize_mixed_precision(data.get("mixed_precision"))
 
 
+def _path_is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _module_origin_under_user_site(module_name: str) -> bool:
+    try:
+        user_site = Path(site.getusersitepackages())
+    except (AttributeError, TypeError):
+        return False
+
+    spec = importlib.util.find_spec(module_name)
+    if spec is None:
+        return False
+
+    candidates: list[str] = []
+    if spec.origin:
+        candidates.append(spec.origin)
+    if spec.submodule_search_locations:
+        candidates.extend(str(location) for location in spec.submodule_search_locations)
+
+    return any(_path_is_relative_to(Path(candidate), user_site) for candidate in candidates)
+
+
+def _should_disable_user_site() -> bool:
+    """Keep portable isolation unless training deps are installed in user site."""
+    return not any(_module_origin_under_user_site(name) for name in ("torch", "accelerate"))
+
+
 def build_accelerate_train_command(
     *,
     trainer_file: str,
@@ -105,7 +139,10 @@ def build_accelerate_train_command(
     customize_env["ACCELERATE_DISABLE_RICH"] = "1"
     customize_env["PYTHONUNBUFFERED"] = "1"
     customize_env["PYTHONWARNINGS"] = "ignore::FutureWarning,ignore::UserWarning"
-    customize_env["PYTHONNOUSERSITE"] = "1"
+    if _should_disable_user_site():
+        customize_env["PYTHONNOUSERSITE"] = "1"
+    else:
+        customize_env.pop("PYTHONNOUSERSITE", None)
     customize_env["NO_COLOR"] = "1"
     customize_env["FORCE_COLOR"] = "0"
     customize_env["TERM"] = "dumb"

--- a/tests/test_process_mixed_precision_launch.py
+++ b/tests/test_process_mixed_precision_launch.py
@@ -99,6 +99,8 @@ def _install_stub_modules() -> None:
     resolver_mod.default_resolver = mock.MagicMock()
     sys.modules["mikazuki.anima_fast_backend.service_resolver"] = resolver_mod
 
+    sys.modules.pop("mikazuki.process", None)
+
 
 # Install stubs only long enough to import ``mikazuki.process``; the imported
 # module keeps its own references to whatever it pulled in, so we restore
@@ -180,6 +182,33 @@ class BuildAccelerateTrainCommandTests(unittest.TestCase):
         self.assertEqual(env["NO_COLOR"], "1")
         self.assertEqual(env["FORCE_COLOR"], "0")
         self.assertEqual(env["TERM"], "dumb")
+
+    def test_disables_user_site_when_training_deps_do_not_need_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            toml_path = Path(tmp) / "train.toml"
+            toml_path.write_text('mixed_precision = "bf16"\n', encoding="utf-8")
+            with mock.patch.object(process, "_module_origin_under_user_site", return_value=False):
+                _args, env, _mp = process.build_accelerate_train_command(
+                    trainer_file="./scripts/stable/train_network.py",
+                    toml_path=str(toml_path),
+                )
+
+        self.assertEqual(env["PYTHONNOUSERSITE"], "1")
+
+    def test_allows_user_site_when_torch_is_installed_there(self):
+        def _under_user_site(name: str) -> bool:
+            return name == "torch"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            toml_path = Path(tmp) / "train.toml"
+            toml_path.write_text('mixed_precision = "bf16"\n', encoding="utf-8")
+            with mock.patch.object(process, "_module_origin_under_user_site", side_effect=_under_user_site):
+                _args, env, _mp = process.build_accelerate_train_command(
+                    trainer_file="./scripts/stable/train_network.py",
+                    toml_path=str(toml_path),
+                )
+
+        self.assertNotIn("PYTHONNOUSERSITE", env)
 
     def test_injects_project_root_onto_pythonpath(self):
         """Regression for #158: accelerate_launch.py imports mikazuki, so the

--- a/tests/test_tokenizer_cache.py
+++ b/tests/test_tokenizer_cache.py
@@ -102,10 +102,11 @@ def test_apply_tokenizer_cache_dir_injects_for_flux_lora(tmp_path: Path, monkeyp
     assert config["tokenizer_cache_dir"] == str(root).replace("\\", "/")
 
 
-def test_build_accelerate_train_command_uses_mirror_launch_entry():
-    from mikazuki.process import build_accelerate_train_command
+def test_build_accelerate_train_command_uses_mirror_launch_entry(monkeypatch):
+    from mikazuki import process
 
-    args, env, _ = build_accelerate_train_command(
+    monkeypatch.setattr(process, "_module_origin_under_user_site", lambda _name: False)
+    args, env, _ = process.build_accelerate_train_command(
         trainer_file="./vendor/sd-scripts/sdxl_train_network.py",
         toml_path="config/autosave/test.toml",
     )


### PR DESCRIPTION
## Summary

Fixes a standard LoRA launch failure where source installs could hide user-site training dependencies from the subprocess. If `torch` or `accelerate` are installed in the Windows user site-packages directory, the training launcher now leaves user site-packages enabled instead of forcing `PYTHONNOUSERSITE=1`.

Portable isolation is still preserved when the training dependencies do not come from user site-packages.

## Why

For issue wochenlong/lora-scripts-next#125, the UI symptom looks like a training-end network request failure, but the actual failure mode can happen before the standard training script becomes visible to the UI: the subprocess starts with user site-packages disabled, then cannot import dependencies installed there.

## Test plan

- `python -m pytest tests/test_standard_run_api.py tests/test_process_mixed_precision_launch.py tests/test_process_train_log_url.py tests/test_tokenizer_cache.py tests/test_train_routing.py`
- Standard LoRA smoke launch reached `scripts/stable/train_network.py` and printed `Network test passed`; the later failure was expected from the fake image used by the smoke fixture.