### PR TITLE
fix(anima-fast): infer preview from strict signal fields

### DIFF
--- a/mikazuki/anima_fast_backend/preview.py
+++ b/mikazuki/anima_fast_backend/preview.py
@@ -6,7 +6,10 @@ import os
 import random
 
 from .adapter import AdapterError, int_value, is_empty
-from mikazuki.utils.train_utils import build_sample_prompt_line as build_kohya_sample_prompt_line
+from mikazuki.utils.train_utils import (
+    build_sample_prompt_line as build_kohya_sample_prompt_line,
+    is_preview_enabled as shared_is_preview_enabled,
+)
 
 DEFAULT_SAMPLE_POSITIVE = (
     "1girl, solo, smile, japanese clothes, kimono, blue eyes, closed mouth, upper body, looki"
@@ -22,14 +25,7 @@ DEFAULT_SAMPLE_NEGATIVE = (
 
 
 def is_preview_enabled(config: dict) -> bool:
-    raw = config.get("enable_preview")
-    if raw in (True, "true", "True", "1", 1):
-        return True
-    if raw in (False, "false", "False", "0", 0):
-        return False
-    if not is_empty(config.get("prompt_file")) or not is_empty(config.get("sample_prompts")):
-        return True
-    return False
+    return shared_is_preview_enabled(config) or not is_empty(config.get("prompt_file"))
 
 
 def _strip_preview_fields(config: dict) -> None:

--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -659,6 +659,7 @@ async def create_toml_file(request: Request):
     config: dict = json.loads(json_data.decode("utf-8"))
     train_utils.fix_config_types(config)
     normalize_custom_args(config)
+    train_utils.ensure_enable_preview_flag(config)
 
     gpu_ids = config.pop("gpu_ids", None)
 

--- a/mikazuki/utils/train_utils.py
+++ b/mikazuki/utils/train_utils.py
@@ -27,6 +27,17 @@ PREVIEW_UI_FIELDS = (
     "prompt_file",
 )
 
+PREVIEW_ENABLE_TEXT_FIELDS = (
+    "sample_prompts",
+    "positive_prompts",
+    "negative_prompts",
+)
+
+PREVIEW_ENABLE_INTERVAL_FIELDS = (
+    "sample_every_n_epochs",
+    "sample_every_n_steps",
+)
+
 
 class ModelType(Enum):
     UNKNOWN = -1
@@ -100,8 +111,43 @@ def is_promopt_like(s):
     return False
 
 
+def _has_non_empty_value(value) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return True
+
+
+def _positive_int_value(value) -> bool:
+    try:
+        return int(value) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def has_preview_enable_signal(config: dict) -> bool:
+    """Return true when preview-only prompt/schedule fields indicate intent.
+
+    This is a transition guard for schemastery serialization dropping or
+    falsifying the ``enable_preview`` discriminator while keeping the preview
+    branch payload. Keep the signal set strict: prompts or sampling interval
+    only, not generic UI defaults like sampler or sample_at_first.
+    """
+    if any(_has_non_empty_value(config.get(key)) for key in PREVIEW_ENABLE_TEXT_FIELDS):
+        return True
+    return any(_positive_int_value(config.get(key)) for key in PREVIEW_ENABLE_INTERVAL_FIELDS)
+
+
 def is_preview_enabled(config: dict) -> bool:
-    return config.get("enable_preview") in (True, "true", "True", "1", 1)
+    return config.get("enable_preview") in (True, "true", "True", "1", 1) or has_preview_enable_signal(config)
+
+
+def ensure_enable_preview_flag(config: dict) -> None:
+    if has_preview_enable_signal(config):
+        config["enable_preview"] = True
 
 
 def has_explicit_sample_prompt_source(config: dict) -> bool:

--- a/tests/test_anima_fast_preview.py
+++ b/tests/test_anima_fast_preview.py
@@ -36,12 +36,13 @@ class AnimaFastPreviewTests(unittest.TestCase):
     def test_preview_disabled_strips_sample_fields(self):
         config = {
             "enable_preview": False,
-            "sample_prompts": "./prompts.txt",
             "sample_at_first": True,
+            "sample_sampler": "euler",
         }
         warnings = apply_anima_fast_preview(config, "/tmp/autosave", "run-1")
         self.assertEqual(warnings, [])
         self.assertNotIn("sample_prompts", config)
+        self.assertNotIn("sample_sampler", config)
 
     def test_preview_enabled_writes_prompt_file_and_adapts(self):
         with tempfile.TemporaryDirectory() as td:
@@ -107,19 +108,38 @@ class AnimaFastPreviewTests(unittest.TestCase):
 
     def test_prompt_defaults_do_not_enable_preview_without_enable_preview_flag(self):
         config = {
-            "sample_every_n_epochs": 2,
-            "positive_prompts": "1girl, solo",
+            "sample_sampler": "euler",
+            "sample_at_first": True,
         }
         self.assertFalse(is_preview_enabled(config))
+
+    def test_strict_preview_signals_enable_preview_without_enable_preview_flag(self):
+        for key, value in (
+            ("sample_prompts", "./prompts.txt"),
+            ("positive_prompts", "1girl, solo"),
+            ("negative_prompts", "lowres"),
+            ("sample_every_n_epochs", 1),
+            ("sample_every_n_steps", 10),
+        ):
+            with self.subTest(key=key):
+                self.assertTrue(is_preview_enabled({key: value}))
 
     def test_explicit_prompt_file_enables_preview_without_enable_preview_flag(self):
         self.assertTrue(is_preview_enabled({"sample_prompts": "./prompts.txt"}))
 
-    def test_preview_disabled_when_enable_preview_false_even_with_prompt_fields(self):
+    def test_preview_false_recovers_when_strict_signal_fields_are_present(self):
         config = {
             "enable_preview": False,
             "positive_prompts": "1girl, solo",
             "sample_every_n_epochs": 2,
+        }
+        self.assertTrue(is_preview_enabled(config))
+
+    def test_preview_false_preserved_without_strict_signal_fields(self):
+        config = {
+            "enable_preview": False,
+            "sample_sampler": "euler",
+            "sample_at_first": True,
         }
         self.assertFalse(is_preview_enabled(config))
 
@@ -143,7 +163,7 @@ class AnimaFastPreviewTests(unittest.TestCase):
             self.assertNotIn("sample_sampler", dumped)
             self.assertNotIn("sample_prompts", dumped)
 
-    def test_frontend_payload_without_enable_preview_does_not_generate_sample_prompts(self):
+    def test_frontend_payload_without_enable_preview_generates_sample_prompts_from_signals(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             runtime = make_runtime(root)
@@ -164,8 +184,8 @@ class AnimaFastPreviewTests(unittest.TestCase):
             apply_anima_fast_preview(config, str(root / "autosave"), "run-fe")
             adapted = adapt_config(config, runtime, "run-fe")
             dumped = dump_flat_toml(adapted.values)
-            self.assertNotIn("sample_prompts", dumped)
-            self.assertNotIn("sample_at_first", dumped)
+            self.assertIn("sample_prompts", dumped)
+            self.assertIn("sample_at_first = true", dumped)
 
     def test_is_preview_enabled_accepts_string_true(self):
         self.assertTrue(is_preview_enabled({"enable_preview": "true"}))

--- a/tests/test_train_utils_preview_gate.py
+++ b/tests/test_train_utils_preview_gate.py
@@ -4,7 +4,7 @@ from mikazuki.utils import train_utils
 
 
 class TrainUtilsPreviewGateTests(unittest.TestCase):
-    def test_disabled_preview_does_not_generate_from_ui_prompt_fields(self):
+    def test_disabled_preview_generates_from_strict_preview_signals(self):
         config = {
             "enable_preview": False,
             "positive_prompts": "1girl, solo",
@@ -19,6 +19,27 @@ class TrainUtilsPreviewGateTests(unittest.TestCase):
             "sample_at_first": True,
             "sample_every_n_epochs": 1,
             "sample_every_n_steps": 10,
+            "prompt_file": "",
+            "train_data_dir": "./train",
+        }
+
+        train_utils.ensure_enable_preview_flag(config)
+
+        self.assertTrue(train_utils.should_generate_sample_prompts(config))
+        self.assertEqual(config["enable_preview"], True)
+        self.assertEqual(config["train_data_dir"], "./train")
+
+    def test_disabled_preview_does_not_generate_from_non_signal_preview_fields(self):
+        config = {
+            "enable_preview": False,
+            "sample_sampler": "euler",
+            "sample_at_first": True,
+            "sample_width": 1024,
+            "sample_height": 1024,
+            "sample_cfg": 4.5,
+            "sample_seed": 42,
+            "sample_steps": 40,
+            "randomly_choice_prompt": False,
             "prompt_file": "",
             "train_data_dir": "./train",
         }
@@ -80,6 +101,34 @@ class TrainUtilsPreviewGateTests(unittest.TestCase):
         }
 
         self.assertTrue(train_utils.should_generate_sample_prompts(config))
+
+    def test_sampling_interval_signal_generates_without_preview_toggle(self):
+        for key in ("sample_every_n_epochs", "sample_every_n_steps"):
+            with self.subTest(key=key):
+                config = {
+                    "enable_preview": False,
+                    key: 1,
+                    "train_data_dir": "./train",
+                }
+
+                train_utils.ensure_enable_preview_flag(config)
+
+                self.assertTrue(train_utils.should_generate_sample_prompts(config))
+                self.assertEqual(config["enable_preview"], True)
+
+    def test_zero_or_empty_sampling_interval_does_not_enable_preview(self):
+        for value in (0, "0", "", None):
+            with self.subTest(value=value):
+                config = {
+                    "enable_preview": False,
+                    "sample_every_n_epochs": value,
+                    "sample_sampler": "euler",
+                }
+
+                train_utils.ensure_enable_preview_flag(config)
+
+                self.assertFalse(train_utils.should_generate_sample_prompts(config))
+                self.assertEqual(config["enable_preview"], False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes wochenlong/lora-scripts-next#162 with a backend transition fallback for Anima Fast preview generation. If schemastery drops or falsifies `enable_preview` but the submitted config still contains strict preview intent signals, the backend now materializes `enable_preview=true` before training preparation.

The fallback is intentionally narrow. It treats these fields as preview enable signals:

- non-empty `sample_prompts`
- non-empty `positive_prompts`
- non-empty `negative_prompts`
- positive `sample_every_n_epochs`
- positive `sample_every_n_steps`

It does not treat generic/default-like preview UI fields such as `sample_sampler`, `sample_at_first`, dimensions, CFG, seed, or steps as enable signals.

## Why

Fast mode reset state does not include preview branch parameters. So when one of the strict prompt or sampling interval fields reaches `/api/run`, it is a strong indication that the preview branch was opened, even if the `enable_preview` discriminator was lost by frontend schema serialization.

## Test plan

- `python -m pytest tests/test_train_utils_preview_gate.py tests/test_anima_fast_preview.py tests/test_standard_run_api.py tests/test_anima_fast_integration_static.py -q`