### PR TITLE
fix(anima): warn for LoKr bf16 DoRA risks

### DIFF
--- a/mikazuki/anima_backend/adapter.py
+++ b/mikazuki/anima_backend/adapter.py
@@ -197,14 +197,15 @@ LOKR_TRAIN_NORM_WARNING = (
     "LyCORIS train_norm is disabled for Anima LoKr because LyCORIS NormModule "
     "can crash on Anima norm layers without affine weights during preview sampling."
 )
-LOKR_BF16_WEIGHT_DECOMPOSITION_WARNING = (
-    "LyCORIS LoKr weight decomposition is disabled for Anima mixed_precision=bf16 "
-    "because some LyCORIS versions keep an unsafe dtype conversion path for "
-    "dora_wd/weight_decomposition."
+LOKR_BF16_DORA_WARNING = (
+    "Anima LoKr mixed_precision=bf16 with DoRA/weight_decomposition can be less "
+    "stable on some LyCORIS/PyTorch combinations. The trainer keeps your "
+    "dora_wd/weight_decomposition settings unchanged."
 )
 LOKR_FULL_MATRIX_WARNING = (
-    "Anima LoKr full_matrix=true uses conservative stability guardrails: "
-    "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1."
+    "Anima LoKr full_matrix=true is a high-risk stability mode. Consider "
+    "disabling full_bf16/full_fp16 and setting scale_weight_norms=1 if the first "
+    "epoch becomes unstable. The trainer keeps your parameters unchanged."
 )
 
 
@@ -304,16 +305,6 @@ def _strip_arg(network_args: list[str], arg_key: str) -> tuple[list[str], bool]:
     return stripped, removed
 
 
-def _strip_args(network_args: list[str], arg_keys: set[str]) -> tuple[list[str], list[str]]:
-    stripped = list(network_args)
-    removed: list[str] = []
-    for arg_key in arg_keys:
-        stripped, did_remove = _strip_arg(stripped, arg_key)
-        if did_remove:
-            removed.append(arg_key)
-    return stripped, removed
-
-
 def adapt_anima_config(
     config: dict[str, Any], *, finetune: bool = False
 ) -> tuple[dict[str, Any], list[str]]:
@@ -375,23 +366,15 @@ def adapt_anima_config(
             if removed_train_norm:
                 warnings.append(LOKR_TRAIN_NORM_WARNING)
             if _network_args_has_truthy_arg(network_args, "full_matrix"):
-                disabled = []
-                for precision_key in ("full_bf16", "full_fp16"):
-                    if source.pop(precision_key, None):
-                        disabled.append(precision_key)
-                if _is_empty_value(source.get("scale_weight_norms")):
-                    source["scale_weight_norms"] = 1
-                if disabled:
-                    warnings.append(
-                        f"{LOKR_FULL_MATRIX_WARNING} Disabled full half precision: {', '.join(disabled)}"
-                    )
-            if str(source.get("mixed_precision", "")).strip().lower() == "bf16":
-                network_args, removed_weight_decomposition = _strip_args(
-                    network_args,
-                    {"dora_wd", "weight_decomposition"},
+                warnings.append(LOKR_FULL_MATRIX_WARNING)
+            if (
+                str(source.get("mixed_precision", "")).strip().lower() == "bf16"
+                and (
+                    _network_args_has_truthy_arg(network_args, "dora_wd")
+                    or _network_args_has_truthy_arg(network_args, "weight_decomposition")
                 )
-                if removed_weight_decomposition:
-                    warnings.append(LOKR_BF16_WEIGHT_DECOMPOSITION_WARNING)
+            ):
+                warnings.append(LOKR_BF16_DORA_WARNING)
         if network_args:
             source["network_args"] = network_args
 

--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -430,6 +430,45 @@ def _anima_lokr_full_matrix_training(config: dict) -> bool:
     return False
 
 
+def _warn_lokr_precision_risks(config: dict) -> None:
+    if not _anima_lokr_training(config):
+        return
+
+    mixed = str(config.get("mixed_precision", "")).strip().lower()
+    full_key = "full_bf16" if mixed == "bf16" else "full_fp16" if mixed == "fp16" else None
+    if full_key and not config.get(full_key):
+        _add_training_warning(
+            config,
+            f"Anima LoKr mixed_precision={mixed} may require {full_key}=true to keep "
+            "adapter and activation dtypes aligned. The trainer keeps your precision "
+            "settings unchanged.",
+        )
+        log.warning(
+            "Anima LoKr mixed_precision=%s may require %s=true to keep adapter and "
+            "activation dtypes aligned. User precision settings are unchanged.",
+            mixed,
+            full_key,
+        )
+
+    if _anima_lokr_full_matrix_training(config):
+        active_full_half = [
+            key
+            for key in ("full_bf16", "full_fp16")
+            if config.get(key)
+        ]
+        if active_full_half or _is_invalid_value(config.get("scale_weight_norms")):
+            _add_training_warning(
+                config,
+                "Anima LoKr full_matrix=true is a high-risk stability mode. "
+                "Consider disabling full_bf16/full_fp16 and setting scale_weight_norms=1 "
+                "if the first epoch becomes unstable. The trainer keeps your parameters unchanged.",
+            )
+            log.warning(
+                "Anima LoKr full_matrix=true is a high-risk stability mode. "
+                "User full precision and scale_weight_norms settings are unchanged."
+            )
+
+
 def apply_anima_training_defaults(config: dict, model_train_type: str):
     if model_train_type not in ANIMA_TRAIN_TYPES:
         return
@@ -482,60 +521,11 @@ def apply_anima_training_defaults(config: dict, model_train_type: str):
                 f"{config.get('optimizer_type')} ({', '.join(disabled)}). "
                 "This keeps trainable LoRA weights in fp32 to reduce loss=nan risk."
             )
-        if _anima_lokr_full_matrix_training(config):
-            had_scale_guardrail = not _is_invalid_value(config.get("scale_weight_norms"))
-            if _is_invalid_value(config.get("scale_weight_norms")):
-                config["scale_weight_norms"] = 1
-            if disabled or not had_scale_guardrail:
-                _add_training_warning(
-                    config,
-                    "Anima LoKr full_matrix=true uses conservative stability guardrails: "
-                    "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1. "
-                    f"Disabled full half precision: {', '.join(disabled) if disabled else 'none'}",
-                )
-                log.warning(
-                    "Anima LoKr full_matrix=true uses conservative stability guardrails: "
-                    "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1. "
-                    "Disabled full half precision: %s",
-                    ", ".join(disabled) if disabled else "none",
-                )
+        _warn_lokr_precision_risks(config)
     elif _anima_lokr_full_matrix_training(config):
-        disabled = []
-        for key in ("full_bf16", "full_fp16"):
-            if config.pop(key, None):
-                disabled.append(key)
-        if _is_invalid_value(config.get("scale_weight_norms")):
-            config["scale_weight_norms"] = 1
-        _add_training_warning(
-            config,
-            "Anima LoKr full_matrix=true uses conservative stability guardrails: "
-            "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1. "
-            f"Disabled full half precision: {', '.join(disabled) if disabled else 'none'}",
-        )
-        log.warning(
-            "Anima LoKr full_matrix=true uses conservative stability guardrails: "
-            "trainable adapter weights stay fp32 and scale_weight_norms defaults to 1. "
-            "Disabled full half precision: %s",
-            ", ".join(disabled) if disabled else "none",
-        )
+        _warn_lokr_precision_risks(config)
     elif _anima_lokr_training(config):
-        # LyCORIS LoKr can hit dtype mismatch under mixed precision when adapter
-        # params stay fp32 while activations are bf16/fp16.
-        mixed = str(config.get("mixed_precision", "")).strip().lower()
-        full_key = "full_bf16" if mixed == "bf16" else "full_fp16" if mixed == "fp16" else None
-        if full_key and not config.get(full_key):
-            config[full_key] = True
-            _add_training_warning(
-                config,
-                f"Enabled {full_key} for Anima LoKr mixed_precision={mixed} to keep "
-                "adapter and activation dtypes aligned.",
-            )
-            log.info(
-                "Enabled %s for Anima LoKr mixed_precision=%s to keep adapter and "
-                "activation dtypes aligned.",
-                full_key,
-                mixed,
-            )
+        _warn_lokr_precision_risks(config)
 
     requested_attn = config.get("attn_mode", "")
     if not requested_attn:

--- a/tests/test_anima_backend_adapter.py
+++ b/tests/test_anima_backend_adapter.py
@@ -147,7 +147,7 @@ class AnimaBackendAdapterTests(unittest.TestCase):
         self.assertNotIn("lokr_factor", adapted)
         self.assertNotIn("use_cp", adapted)
         self.assertNotIn("full_matrix", adapted)
-        self.assertEqual(warnings, [])
+        self.assertTrue(any("full_matrix=true" in warning for warning in warnings))
 
     def test_lycoris_preset_and_fields_coexist(self):
         config = {
@@ -208,7 +208,7 @@ class AnimaBackendAdapterTests(unittest.TestCase):
         self.assertNotIn("train_norm=True", adapted["network_args"])
         self.assertTrue(any("train_norm" in warning and "LoKr" in warning for warning in warnings))
 
-    def test_lokr_bf16_disables_weight_decomposition_args(self):
+    def test_lokr_bf16_warns_and_keeps_weight_decomposition_args(self):
         config = {
             "network_module": "lycoris.kohya",
             "lycoris_algo": "lokr",
@@ -225,13 +225,15 @@ class AnimaBackendAdapterTests(unittest.TestCase):
         self.assertIn("algo=lokr", adapted["network_args"])
         self.assertIn("factor=-1", adapted["network_args"])
         self.assertIn("full_matrix=True", adapted["network_args"])
-        self.assertNotIn("dora_wd=True", adapted["network_args"])
-        self.assertNotIn("weight_decomposition=True", adapted["network_args"])
+        self.assertIn("dora_wd=True", adapted["network_args"])
+        self.assertIn("weight_decomposition=True", adapted["network_args"])
+        self.assertTrue(adapted["full_bf16"])
         self.assertTrue(
-            any("weight decomposition" in warning and "mixed_precision=bf16" in warning for warning in warnings)
+            any("DoRA/weight_decomposition" in warning and "keeps your" in warning for warning in warnings)
         )
+        self.assertTrue(any("full_matrix=true" in warning for warning in warnings))
 
-    def test_lokr_full_matrix_disables_full_half_precision_in_adapter(self):
+    def test_lokr_full_matrix_warns_without_changing_user_params(self):
         config = {
             "network_module": "lycoris.kohya",
             "lycoris_algo": "lokr",
@@ -243,8 +245,8 @@ class AnimaBackendAdapterTests(unittest.TestCase):
         adapted, warnings = adapt_anima_config(config)
 
         self.assertIn("full_matrix=True", adapted["network_args"])
-        self.assertNotIn("full_bf16", adapted)
-        self.assertEqual(adapted["scale_weight_norms"], 1)
+        self.assertTrue(adapted["full_bf16"])
+        self.assertNotIn("scale_weight_norms", adapted)
         self.assertTrue(any("full_matrix=true" in warning for warning in warnings))
 
     def test_lokr_fp16_keeps_weight_decomposition_args(self):

--- a/tests/test_anima_training_defaults.py
+++ b/tests/test_anima_training_defaults.py
@@ -29,7 +29,7 @@ class AnimaTrainingDefaultsTests(unittest.TestCase):
         self.assertNotIn("full_bf16", config)
         self.assertEqual(config["unet_lr"], 5e-5)
 
-    def test_anima_auto_enables_full_bf16_for_lokr_bf16(self):
+    def test_anima_lokr_bf16_warns_without_changing_full_precision(self):
         config = {
             "mixed_precision": "bf16",
             "optimizer_type": "AdamW8bit",
@@ -41,10 +41,10 @@ class AnimaTrainingDefaultsTests(unittest.TestCase):
 
         apply_anima_training_defaults(config, "anima-lora")
 
-        self.assertTrue(config.get("full_bf16"))
-        self.assertIn("Enabled full_bf16 for Anima LoKr", config["_training_warnings"][0])
+        self.assertNotIn("full_bf16", config)
+        self.assertIn("may require full_bf16=true", config["_training_warnings"][0])
 
-    def test_anima_lokr_full_matrix_uses_conservative_guardrails(self):
+    def test_anima_lokr_full_matrix_warns_without_changing_user_params(self):
         config = {
             "mixed_precision": "bf16",
             "full_bf16": True,
@@ -57,8 +57,8 @@ class AnimaTrainingDefaultsTests(unittest.TestCase):
 
         apply_anima_training_defaults(config, "anima-lora")
 
-        self.assertNotIn("full_bf16", config)
-        self.assertEqual(config["scale_weight_norms"], 1)
+        self.assertTrue(config["full_bf16"])
+        self.assertNotIn("scale_weight_norms", config)
         self.assertIn("full_matrix=true", config["_training_warnings"][0])
 
     def test_anima_disables_full_bf16_for_came(self):
@@ -92,7 +92,7 @@ class AnimaTrainingDefaultsTests(unittest.TestCase):
 
         self.assertEqual(config["mixed_precision"], "bf16")
         self.assertNotIn("full_fp16", config)
-        self.assertEqual(config["scale_weight_norms"], 1)
+        self.assertNotIn("scale_weight_norms", config)
         self.assertTrue(
             any("full_matrix=true" in warning for warning in config["_training_warnings"])
         )


### PR DESCRIPTION
## Summary
- Preserve user-specified LoKr bf16 DoRA and weight-decomposition parameters instead of stripping them in the adapter.
- Change LoKr full-matrix precision handling from silent parameter rewrites to visible warnings.
- Update regression tests to lock warning-only behavior for risky LoKr bf16 combinations.

## Test plan
- `python -m pytest tests/test_anima_backend_adapter.py tests/test_anima_training_defaults.py -q`
- Minimal LyCORIS 3.3.0 LoKr DoRA bf16 forward/backward smoke check

Made with [Cursor](https://cursor.com)