### PR TITLE
fix(anima): patch LoKr DoRA bf16 runtime dtype

### DIFF
--- a/mikazuki/anima_backend/lycoris_patch.py
+++ b/mikazuki/anima_backend/lycoris_patch.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import logging
+
+import torch
+
+
+log = logging.getLogger(__name__)
+
+
+def _lycoris_lora_version() -> str | None:
+    try:
+        return importlib.metadata.version("lycoris-lora")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _patched_lokr_forward(self, x: torch.Tensor, *args, **kwargs):
+    if self.module_dropout and self.training:
+        if torch.rand(1, device=x.device) < self.module_dropout:
+            return self.org_forward(x, *args, **kwargs)
+
+    if self.bypass_mode:
+        return self.bypass_forward(x, self.multiplier)
+
+    base = self.org_forward(x, *args, **kwargs)
+    base_weight = self._current_weight().to(x.device)
+    diff_weight = self.get_weight(self.shape).to(base_weight.dtype) * self.scalar
+
+    if self.wd:
+        new_weight = self.apply_weight_decompose(
+            base_weight + diff_weight, self.multiplier
+        )
+    elif self.multiplier == 1:
+        new_weight = base_weight + diff_weight
+    else:
+        new_weight = base_weight + diff_weight * self.multiplier
+
+    delta_weight = new_weight - base_weight
+    if x.is_floating_point() and delta_weight.dtype != x.dtype:
+        delta_weight = delta_weight.to(device=x.device, dtype=x.dtype)
+    else:
+        delta_weight = delta_weight.to(device=x.device)
+    delta = self.op(x, delta_weight, None, **self.kw_dict)
+    return base + delta
+
+
+def patch_lokr_dora_bf16_forward() -> bool:
+    """Patch LyCORIS 3.3 LoKr DoRA delta-weight dtype mismatch (#161)."""
+
+    version = _lycoris_lora_version()
+    if version != "3.3.0":
+        return False
+
+    try:
+        lokr = importlib.import_module("lycoris.modules.lokr")
+    except Exception as exc:
+        log.warning("Could not import LyCORIS LoKr for dtype patch: %s", exc)
+        return False
+
+    module_cls = getattr(lokr, "LokrModule", None)
+    if module_cls is None or getattr(module_cls, "_sd_trainer_lokr_dora_bf16_patch", False):
+        return False
+
+    module_cls.forward = _patched_lokr_forward
+    module_cls._sd_trainer_lokr_dora_bf16_patch = True
+    log.info("Applied LyCORIS 3.3 LoKr DoRA bf16 dtype patch.")
+    return True

--- a/scripts/dev/anima_train_network.py
+++ b/scripts/dev/anima_train_network.py
@@ -11,6 +11,7 @@ if ROOT_STR not in sys.path:
     sys.path.insert(0, ROOT_STR)
 
 from mikazuki.anima_backend.adapter import adapt_anima_config
+from mikazuki.anima_backend.lycoris_patch import patch_lokr_dora_bf16_forward
 from mikazuki.anima_backend.upstream import (
     load_toml_file,
     prefer_upstream_imports,
@@ -65,6 +66,7 @@ def main() -> None:
     verify_pinned_commit(root)
     upstream_path = resolve_upstream_path(root)
     prefer_upstream_imports(upstream_path)
+    patch_lokr_dora_bf16_forward()
     _rewrite_config_file(sys.argv)
     script = upstream_entrypoint(upstream_path, _read_backend_entrypoint(root))
     if os.environ.get("ANIMA_BACKEND_WRAPPER_SMOKE") == "1":

--- a/tests/test_anima_lycoris_patch.py
+++ b/tests/test_anima_lycoris_patch.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import sys
+import unittest
+from unittest import mock
+
+import torch
+
+from mikazuki.anima_backend.lycoris_patch import patch_lokr_dora_bf16_forward
+
+
+class FakeLokrModule:
+    def __init__(self):
+        self.module_dropout = 0.0
+        self.training = True
+        self.bypass_mode = False
+        self.multiplier = 1
+        self.shape = (2, 2)
+        self.scalar = torch.tensor(1.0)
+        self.wd = True
+        self.kw_dict = {}
+        self.seen_dtype = None
+
+    def org_forward(self, x, *args, **kwargs):
+        return torch.zeros_like(x)
+
+    def _current_weight(self):
+        return torch.zeros(2, 2, dtype=torch.bfloat16)
+
+    def get_weight(self, shape):
+        return torch.ones(shape, dtype=torch.bfloat16)
+
+    def apply_weight_decompose(self, weight, multiplier):
+        return weight.float()
+
+    def op(self, x, delta_weight, bias, **kwargs):
+        self.seen_dtype = delta_weight.dtype
+        return x @ delta_weight
+
+
+class AnimaLycorisPatchTests(unittest.TestCase):
+    def test_patch_casts_lokr_dora_delta_weight_to_input_dtype(self):
+        fake_module = SimpleNamespace(LokrModule=FakeLokrModule)
+        with mock.patch("mikazuki.anima_backend.lycoris_patch._lycoris_lora_version", return_value="3.3.0"), \
+            mock.patch("importlib.import_module", return_value=fake_module):
+            self.assertTrue(patch_lokr_dora_bf16_forward())
+
+        module = FakeLokrModule()
+        x = torch.ones(2, 2, dtype=torch.bfloat16)
+        y = module.forward(x)
+
+        self.assertEqual(module.seen_dtype, torch.bfloat16)
+        self.assertEqual(y.dtype, torch.bfloat16)
+
+    def tearDown(self):
+        sys.modules.pop("lycoris.modules.lokr", None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes wochenlong/lora-scripts-next#161 by applying a targeted runtime patch for LyCORIS 3.3.0 LoKr. The Anima wrapper now installs the patch before upstream training starts, and the patched LoKr forward aligns `delta_weight` to the input tensor device and dtype before calling `self.op`.

This keeps user LoKr, DoRA, bf16, and full-matrix parameters unchanged. The existing compatibility warnings still surface risky combinations, but the trainer no longer trips the bf16/float32 matmul mismatch reported in the issue.

## Test Plan

- `python -m pytest tests/test_anima_lycoris_patch.py tests/test_anima_backend_adapter.py tests/test_anima_training_defaults.py -q` (31 passed)
- Minimal LyCORIS 3.3.0 LoKr + DoRA + bf16 forward/backward smoke passed on CUDA.
- One-step Anima training smoke with LoKr + DoRA/weight decomposition + full_matrix + bf16 + full_bf16 completed and saved checkpoints without the `BFloat16 != float32` error.