### PR TITLE
fix(anima-fast): honor batch size and repeats

### DIFF
--- a/mikazuki/anima_fast_backend/adapter.py
+++ b/mikazuki/anima_fast_backend/adapter.py
@@ -88,6 +88,8 @@ FAST_CACHE_PAIRS = (
     ("cache_text_encoder_outputs", "cache_text_encoder_outputs_to_disk"),
 )
 
+FAST_DATASET_REPEAT_FIELDS = {"dataset_repeats", "num_repeats", "repeats", "repeat"}
+
 
 @dataclass
 class AdaptedConfig:
@@ -132,6 +134,21 @@ def resolution_tokens(value: Any) -> int:
     if width <= 0 or height <= 0:
         return 0
     return (width // 16) * (height // 16)
+
+
+def resolution_pair(value: Any, default: int = 1024) -> list[int]:
+    if value is None:
+        return [default, default]
+    if isinstance(value, int):
+        return [value, value]
+    text = str(value).replace("x", ",").replace(" ", "")
+    parts = [p for p in text.split(",") if p]
+    if len(parts) == 1:
+        size = int_value(parts[0], default)
+        return [size, size]
+    if len(parts) >= 2:
+        return [int_value(parts[0], default), int_value(parts[1], default)]
+    return [default, default]
 
 
 def normalize_kv_args(values: Any) -> list[str]:
@@ -307,6 +324,16 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
             continue
         values[key] = value
 
+    train_batch_size = int_value(values.get("train_batch_size"), 0)
+    if train_batch_size > 0:
+        values["batch_size"] = train_batch_size
+
+    for repeat_key in FAST_DATASET_REPEAT_FIELDS:
+        repeats = int_value(source.get(repeat_key), 0)
+        if repeats > 0:
+            values["dataset_repeats"] = repeats
+            break
+
     values.setdefault("torch_compile", True)
     values.setdefault("static_token_count", 4096)
     if truthy(values.get("torch_compile")):
@@ -384,6 +411,42 @@ def toml_scalar(value: Any) -> str:
 
 def dump_flat_toml(values: dict[str, Any]) -> str:
     return "".join(f"{key} = {toml_scalar(value)}\n" for key, value in values.items())
+
+
+def dump_fast_dataset_toml(values: dict[str, Any]) -> str:
+    batch_size = int_value(values.get("batch_size") or values.get("train_batch_size"), 1) or 1
+    repeats = int_value(values.get("dataset_repeats") or values.get("num_repeats"), 1) or 1
+    dataset_values = {
+        "resolution": resolution_pair(values.get("resolution", "1024,1024")),
+        "batch_size": batch_size,
+        "enable_bucket": values.get("enable_bucket", True),
+        "validation_split_num": int_value(values.get("validation_split_num"), 16),
+        "validation_seed": int_value(values.get("validation_seed"), 42),
+    }
+    for key in ("min_bucket_reso", "max_bucket_reso", "bucket_reso_steps", "bucket_no_upscale", "validation_split"):
+        if not is_empty(values.get(key)):
+            dataset_values[key] = values[key]
+
+    subset_values = {
+        "image_dir": values.get("resized_image_dir"),
+        "cache_dir": values.get("lora_cache_dir"),
+        "num_repeats": repeats,
+        "recursive": values.get("recursive", True),
+    }
+    if not is_empty(values.get("path_pattern")):
+        subset_values["path_pattern"] = values["path_pattern"]
+
+    lines = ["[general]\n"]
+    lines.append(f"caption_extension = {toml_scalar(values.get('caption_extension', '.txt'))}\n")
+    if not is_empty(values.get("keep_tokens")):
+        lines.append(f"keep_tokens = {toml_scalar(values['keep_tokens'])}\n")
+    else:
+        lines.append("keep_tokens = 3\n")
+    lines.append("\n[[datasets]]\n")
+    lines.extend(f"{key} = {toml_scalar(value)}\n" for key, value in dataset_values.items())
+    lines.append("\n  [[datasets.subsets]]\n")
+    lines.extend(f"  {key} = {toml_scalar(value)}\n" for key, value in subset_values.items() if not is_empty(value))
+    return "".join(lines)
 
 
 def ensure_fast_run_log_dirs(values: dict[str, Any], now: datetime | None = None) -> list[Path]:

--- a/mikazuki/app/api.py
+++ b/mikazuki/app/api.py
@@ -37,6 +37,7 @@ from mikazuki.anima_fast_backend import TRAIN_TYPE as ANIMA_FAST_TRAIN_TYPE
 from mikazuki.anima_fast_backend.adapter import (
     AdapterError,
     adapt_config,
+    dump_fast_dataset_toml,
     dump_flat_toml,
     ensure_fast_run_log_dirs,
 )
@@ -578,7 +579,10 @@ def _write_anima_fast_toml(config: dict, timestamp: str, autosave_dir: str) -> t
 
 def _write_adapted_anima_fast_toml(values: dict, warnings: list[str], run_id: str, autosave_dir: str) -> tuple[Path, dict, list[str]]:
     toml_file = Path(autosave_dir) / f"{run_id}.toml"
+    dataset_file = Path(autosave_dir) / f"{run_id}-dataset.toml"
     ensure_fast_run_log_dirs(values)
+    values["dataset_config"] = dataset_file.resolve().as_posix()
+    dataset_file.write_text(dump_fast_dataset_toml(values), encoding="utf-8")
     toml_file.write_text(dump_flat_toml(values), encoding="utf-8")
     return toml_file, values, warnings
 

--- a/mikazuki/schema/anima-lora-fast.ts
+++ b/mikazuki/schema/anima-lora-fast.ts
@@ -46,6 +46,7 @@ Schema.intersect([
         max_train_epochs: Schema.number().min(1).default(1).description("最大训练 epoch；设置后 Anima 会按 epoch 和 dataloader 长度重算 step"),
         max_train_steps: Schema.number().min(1).description("最大训练 step；仅在 max_train_epochs 为空时按 step 控制"),
         train_batch_size: Schema.number().min(1).default(1).description("批量大小"),
+        dataset_repeats: Schema.number().min(1).default(1).description("数据集重复次数"),
         gradient_checkpointing: Schema.boolean().default(true).description("梯度检查点（省显存）。开启时请勿选 compile_mode=full"),
         gradient_accumulation_steps: Schema.number().min(1).default(1).description("梯度累加步数"),
         seed: Schema.number().step(1).default(42).description("随机种子"),

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -11,6 +11,7 @@ from mikazuki.anima_fast_backend.adapter import (
     adapt_config,
     dataset_cache_slug,
     dump_flat_toml,
+    dump_fast_dataset_toml,
     ensure_fast_run_log_dirs,
 )
 from mikazuki.anima_fast_backend.extension_state import (
@@ -216,6 +217,43 @@ class AdapterTests(unittest.TestCase):
         self.assertEqual(resized, (root / ".cache" / "anima_fast" / "data_train_data" / "resized").resolve())
         self.assertEqual(lora_cache, (root / ".cache" / "anima_fast" / "data_train_data" / "lora").resolve())
         self.assertNotIn("20260101-run", resized.as_posix())
+
+    def test_adapt_config_maps_fast_dataset_batch_size_and_repeats(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            adapted = adapt_config(
+                {
+                    "lora_type": "lora",
+                    "train_batch_size": 4,
+                    "dataset_repeats": 7,
+                },
+                runtime,
+                "run-1",
+            )
+
+        self.assertEqual(adapted.values["train_batch_size"], 4)
+        self.assertEqual(adapted.values["batch_size"], 4)
+        self.assertEqual(adapted.values["dataset_repeats"], 7)
+
+    def test_dump_fast_dataset_toml_writes_dataset_overrides(self):
+        text = dump_fast_dataset_toml(
+            {
+                "resized_image_dir": "D:/data/resized",
+                "lora_cache_dir": "D:/data/lora",
+                "caption_extension": ".txt",
+                "resolution": "1024,1024",
+                "enable_bucket": True,
+                "train_batch_size": 4,
+                "dataset_repeats": 7,
+            }
+        )
+
+        self.assertIn("[[datasets]]", text)
+        self.assertIn("resolution = [1024, 1024]", text)
+        self.assertIn("batch_size = 4", text)
+        self.assertIn("[[datasets.subsets]]", text)
+        self.assertIn("num_repeats = 7", text)
 
     def test_dataset_cache_slug_from_relative_path(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- Generate an Anima Fast dataset config alongside the main autosave TOML so dataset batch size and repeats are not overwritten by upstream base defaults.
- Map `train_batch_size` into dataset `batch_size` and expose `dataset_repeats` in the Fast schema.
- Add regression coverage for Fast dataset batch/repeat TOML generation.

Fixes #181

## Test Plan
- [x] `python -m pytest tests/test_anima_fast_backend.py tests/test_anima_fast_plugin_api.py tests/test_anima_fast_integration_static.py tests/test_anima_fast_settings.py tests/test_anima_fast_preprocess.py tests/test_anima_fast_preview.py -q`
- [x] Verified upstream Anima Fast loader reads generated dataset config as `{'batch_size': 4, 'num_repeats': 7}`