### PR TITLE
fix(portable): hub auto routing and tagger download progress

### DIFF
--- a/mikazuki/china_hub.py
+++ b/mikazuki/china_hub.py
@@ -19,6 +19,10 @@ import os
 from typing import Any, Callable
 
 _PATCHED = False
+_ORIGINAL_HF_HUB_DOWNLOAD: Callable[..., Any] | None = None
+
+# WD/CL tagger ONNX repos are Hugging Face–only; ModelScope returns 404 for them.
+_HF_ONLY_REPO_PREFIXES = ("SmilingWolf/", "cella110n/")
 
 # Hugging Face repo id → ModelScope repo id.
 #
@@ -49,6 +53,34 @@ def remap_hf_repo_id(repo_id: str) -> str:
     return HF_TO_MODELSCOPE_REPOS.get(repo_id, repo_id)
 
 
+def is_hf_only_repo(repo_id: str) -> bool:
+    """Repos that must download from huggingface.co (not ModelScope)."""
+    return str(repo_id or "").startswith(_HF_ONLY_REPO_PREFIXES)
+
+
+def _hf_hub_download_direct(*args: Any, **kwargs: Any) -> Any:
+    """Download via pre-patch huggingface_hub (bypass ModelScope patch)."""
+    if _ORIGINAL_HF_HUB_DOWNLOAD is None:
+        import huggingface_hub
+
+        return huggingface_hub.hf_hub_download(*args, **kwargs)
+
+    prev_endpoint = os.environ.get("HF_ENDPOINT")
+    try:
+        # hf-mirror only mirrors metadata; large ONNX files must come from hf.co.
+        os.environ.pop("HF_ENDPOINT", None)
+        if args:
+            args = (remap_hf_repo_id(str(args[0])), *args[1:])
+        if kwargs.get("repo_id") is not None:
+            kwargs = {**kwargs, "repo_id": remap_hf_repo_id(str(kwargs["repo_id"]))}
+        return _ORIGINAL_HF_HUB_DOWNLOAD(*args, **kwargs)
+    finally:
+        if prev_endpoint is None:
+            os.environ.pop("HF_ENDPOINT", None)
+        else:
+            os.environ["HF_ENDPOINT"] = prev_endpoint
+
+
 def hub_backend() -> str:
     """Return ``modelscope`` or ``huggingface`` for download routing."""
     explicit = (os.environ.get("MIKAZUKI_HUB_BACKEND") or "auto").strip().lower()
@@ -75,6 +107,9 @@ def hub_backend() -> str:
 
 def _wrap_repo_remap(fn: Callable[..., Any]) -> Callable[..., Any]:
     def wrapped(*args: Any, **kwargs: Any) -> Any:
+        repo_id = str(kwargs.get("repo_id") or (args[0] if args else ""))
+        if is_hf_only_repo(repo_id):
+            return _hf_hub_download_direct(*args, **kwargs)
         if args:
             args = (remap_hf_repo_id(str(args[0])), *args[1:])
         if kwargs.get("repo_id") is not None:
@@ -132,7 +167,7 @@ def enable_china_hub(*, force: bool = False) -> bool:
 
     Safe to call multiple times. Returns True when ModelScope patch is active.
     """
-    global _PATCHED
+    global _PATCHED, _ORIGINAL_HF_HUB_DOWNLOAD
     if _PATCHED:
         return True
     if not force and hub_backend() != "modelscope":
@@ -142,6 +177,14 @@ def enable_china_hub(*, force: bool = False) -> bool:
         from modelscope.utils.hf_util import patch_hub
     except ImportError:
         return False
+
+    try:
+        import huggingface_hub
+
+        if _ORIGINAL_HF_HUB_DOWNLOAD is None:
+            _ORIGINAL_HF_HUB_DOWNLOAD = huggingface_hub.hf_hub_download
+    except ImportError:
+        pass
 
     try:
         import diffusers  # noqa: F401

--- a/mikazuki/tagger/jobs.py
+++ b/mikazuki/tagger/jobs.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from mikazuki.tagger.interrogator import available_interrogators, on_interrogate
 from mikazuki.tagger.model_fetch import (
+    describe_interrogator_asset_status,
     download_interrogator_assets,
     ensure_interrogator_assets,
+    format_tagger_download_error,
     interrogator_assets_ready,
     use_download_endpoint,
 )
@@ -22,6 +24,9 @@ def run_prefetch_job(req) -> None:
     if not tagger_progress.try_begin("downloading", model_key, "正在准备下载…"):
         return
 
+    ready, status_msg = describe_interrogator_asset_status(model_key, interrogator)
+    print(status_msg, flush=True)
+
     try:
         with use_download_endpoint(getattr(req, "download_endpoint", "")):
             if interrogator_assets_ready(interrogator, model_key):
@@ -34,7 +39,9 @@ def run_prefetch_job(req) -> None:
         if tagger_progress.is_cancel_requested():
             tagger_progress.finish_cancelled()
         else:
-            tagger_progress.finish_error(str(exc))
+            hint = format_tagger_download_error(model_key, exc)
+            print(f"[tagger] prefetch failed: {hint}", flush=True)
+            tagger_progress.finish_error(hint)
 
 
 def run_interrogate_job(req) -> None:
@@ -54,6 +61,10 @@ def run_interrogate_job(req) -> None:
     if not tagger_progress.try_begin(initial_phase, model_key, initial_message):
         return
 
+    ready, status_msg = describe_interrogator_asset_status(model_key, interrogator)
+    print(f"[tagger] 打标任务: model={model_key}, path={req.path}", flush=True)
+    print(status_msg, flush=True)
+
     try:
         with use_download_endpoint(getattr(req, "download_endpoint", "")):
             if needs_download:
@@ -68,7 +79,9 @@ def run_interrogate_job(req) -> None:
             if tagger_progress.is_cancel_requested():
                 tagger_progress.finish_cancelled()
             else:
-                tagger_progress.finish_error(str(exc))
+                hint = format_tagger_download_error(model_key, exc)
+                print(f"[tagger] load failed: {hint}", flush=True)
+                tagger_progress.finish_error(hint)
             return
 
         result = on_interrogate(
@@ -107,4 +120,6 @@ def run_interrogate_job(req) -> None:
         if tagger_progress.is_cancel_requested():
             tagger_progress.finish_cancelled()
         else:
-            tagger_progress.finish_error(str(exc))
+            hint = format_tagger_download_error(model_key, exc)
+            print(f"[tagger] failed: {hint}", flush=True)
+            tagger_progress.finish_error(hint)

--- a/mikazuki/tagger/model_fetch.py
+++ b/mikazuki/tagger/model_fetch.py
@@ -9,7 +9,11 @@ from typing import TYPE_CHECKING, Iterator
 
 from huggingface_hub import hf_hub_download, try_to_load_from_cache
 
-from mikazuki.tagger.local_models import asset_filenames, local_model_asset_paths
+from mikazuki.tagger.local_models import (
+    asset_filenames,
+    local_model_asset_paths,
+    local_model_dir,
+)
 from mikazuki.tagger.progress import TaggerCancelled, tagger_progress
 
 if TYPE_CHECKING:
@@ -44,6 +48,90 @@ def _file_cached(kwargs: dict, filename: str) -> bool:
         return False
 
 
+def describe_interrogator_asset_status(
+    model_key: str,
+    interrogator: "Interrogator",
+) -> tuple[bool, str]:
+    """Return (ready, multi-line console message)."""
+    local_paths = local_model_asset_paths(model_key, interrogator)
+    if local_paths:
+        return True, (
+            f"[tagger] 模型 {model_key} 已在本地: {local_paths[0].parent}"
+        )
+
+    kwargs = _hf_kwargs(interrogator)
+    repo_id = kwargs.get("repo_id", model_key)
+    files = _asset_filenames(interrogator)
+    local_dir = local_model_dir(model_key)
+    missing = [name for name in files if not _file_cached(kwargs, name)]
+    file_hint = ", ".join(missing or files)
+    return False, (
+        f"[tagger] 模型 {model_key} 未在本地\n"
+        f"  可手动放置目录: {local_dir}\n"
+        f"  缺少文件: {file_hint}\n"
+        f"  将尝试从 Hugging Face 下载: {repo_id}"
+    )
+
+
+def format_tagger_download_error(model_key: str, exc: BaseException) -> str:
+    """User-facing hint: missing model vs network vs hub mis-route."""
+    message = str(exc).strip()
+    lowered = message.lower()
+    exc_name = type(exc).__name__
+
+    if exc_name in {"LocalEntryNotFoundError", "OfflineModeIsEnabled"}:
+        return (
+            f"打标模型 {model_key} 未在本地，且无法从 Hugging Face 拉取文件。"
+            " 请检查网络能否访问 huggingface.co，或将 model.onnx / selected_tags.csv "
+            f"放入 tagger-models/wd14/{model_key}/ 后重试。"
+            f"（{exc_name}: {message}）"
+        )
+
+    if exc_name in {"ConnectTimeout", "ReadTimeout", "TimeoutError"} or "timeout" in lowered:
+        return (
+            f"下载打标模型 {model_key} 超时，可能是网络不稳定或无法访问 Hugging Face。"
+            f" 可稍后重试，或手动下载后放入 tagger-models/wd14/{model_key}/。"
+            f"（{message}）"
+        )
+
+    if exc_name in {"ConnectionError", "ConnectError", "NetworkError"} or "connection" in lowered:
+        return (
+            f"无法连接 Hugging Face 下载打标模型 {model_key}。"
+            " 请检查网络/代理；整合包默认模型已内置，其它模型需能访问 huggingface.co。"
+            f"（{message}）"
+        )
+
+    if exc_name == "HTTPError" or "404" in message:
+        if "modelscope" in lowered:
+            return (
+                f"魔搭 ModelScope 上不存在打标模型 {model_key}（SmilingWolf 系列仅托管在 Hugging Face）。"
+                " 请勿强制 MIKAZUKI_HUB_BACKEND=modelscope；"
+                f"或手动放入 tagger-models/wd14/{model_key}/。"
+                f"（{message}）"
+            )
+        return (
+            f"在 Hugging Face 未找到打标模型 {model_key} 的文件。"
+            f" 请确认模型名称正确，或手动放入 tagger-models/wd14/{model_key}/。"
+            f"（{message}）"
+        )
+
+    if "modelscope" in lowered and ("not exist" in lowered or "not exists" in lowered):
+        return (
+            f"魔搭 ModelScope 上不存在打标模型 {model_key}（SmilingWolf 系列仅托管在 Hugging Face）。"
+            " 请勿强制 MIKAZUKI_HUB_BACKEND=modelscope；"
+            f"或手动放入 tagger-models/wd14/{model_key}/。"
+            f"（{message}）"
+        )
+
+    if "repository not found" in lowered or "repo not found" in lowered:
+        return (
+            f"Hugging Face 仓库不存在: {model_key}。"
+            f"（{message}）"
+        )
+
+    return f"下载打标模型 {model_key} 失败: {message}"
+
+
 def interrogator_assets_ready(interrogator: "Interrogator", model_key: str | None = None) -> bool:
     """Return True when all HF files for this interrogator are already in the local cache."""
     if model_key and local_model_asset_paths(model_key, interrogator):
@@ -67,11 +155,12 @@ def _hf_tqdm_class():
 
 
 class _TaggerDownloadTqdm(_hf_tqdm_class()):
-    """Bridge Hugging Face hub tqdm bytes to tagger_progress API."""
+    """Bridge Hugging Face hub tqdm bytes to tagger_progress API and console."""
 
     _file_index: int = 1
     _file_total: int = 1
     _filename: str = ""
+    _last_print_pct: int = -1
 
     def update(self, n=1):
         if tagger_progress.is_cancel_requested():
@@ -86,6 +175,17 @@ class _TaggerDownloadTqdm(_hf_tqdm_class()):
             bytes_current=current,
             bytes_total=total,
         )
+        if total > 0:
+            pct = min(100, int(current * 100 / total))
+            if pct >= self._last_print_pct + 10 or (pct == 100 and self._last_print_pct < 100):
+                self._last_print_pct = pct
+                mb_done = current / (1024 * 1024)
+                mb_total = total / (1024 * 1024)
+                print(
+                    f"[tagger] 下载 {self._filename}: {pct}% "
+                    f"({mb_done:.1f}/{mb_total:.1f} MB)",
+                    flush=True,
+                )
         return result
 
 
@@ -97,6 +197,7 @@ def _hub_download_progress(file_index: int, file_total: int, filename: str) -> I
         _file_index = file_index
         _file_total = file_total
         _filename = filename
+        _last_print_pct = -1
 
     hf_tqdm_module = _hf_tqdm_module()
     originals = {
@@ -124,18 +225,45 @@ def download_interrogator_assets(
     continue_to_tagging=False: prefetch finished → phase done + release busy.
     continue_to_tagging=True: keep busy, switch to tagging phase for follow-up job.
     """
+    ready, status_msg = describe_interrogator_asset_status(model_key, interrogator)
+    print(status_msg, flush=True)
+    if ready:
+        msg = f"模型 {model_key} 已在本地"
+        if continue_to_tagging:
+            tagger_progress.complete_download_for_tagging(model_key, f"{msg}，开始打标…")
+        else:
+            tagger_progress.finish_download_success(msg)
+        return
+
     kwargs = _hf_kwargs(interrogator)
     files = _asset_filenames(interrogator)
     if not files:
         raise ValueError(f"模型 {model_key} 无可用下载文件列表")
 
     tagger_progress.begin_download(model_key, len(files), message="正在下载模型…")
+    repo_id = kwargs.get("repo_id", model_key)
+    print(
+        f"[tagger] 开始下载 {model_key}（共 {len(files)} 个文件，来源 {repo_id}）…",
+        flush=True,
+    )
 
     for index, filename in enumerate(files, start=1):
         tagger_progress.check_cancelled()
         tagger_progress.set_download(index, len(files), filename)
-        with _hub_download_progress(index, len(files), filename):
-            hf_hub_download(**kwargs, filename=filename)
+        print(
+            f"[tagger] ({index}/{len(files)}) {filename} …",
+            flush=True,
+        )
+        try:
+            with _hub_download_progress(index, len(files), filename):
+                path = hf_hub_download(**kwargs, filename=filename)
+            print(f"[tagger] 已完成 {filename} -> {path}", flush=True)
+        except TaggerCancelled:
+            raise
+        except Exception as exc:
+            hint = format_tagger_download_error(model_key, exc)
+            print(f"[tagger] 失败: {hint}", flush=True)
+            raise RuntimeError(hint) from exc
         tagger_progress.set_download_bytes(
             file_index=index,
             file_total=len(files),
@@ -144,6 +272,7 @@ def download_interrogator_assets(
             bytes_total=0,
         )
 
+    print(f"[tagger] 模型 {model_key} 全部文件下载完成", flush=True)
     if continue_to_tagging:
         tagger_progress.complete_download_for_tagging(
             model_key,

--- a/scripts/portable/README.md
+++ b/scripts/portable/README.md
@@ -45,7 +45,11 @@
 | Python | `python_embeded` | 系统 / `venv` |
 | 入口 | `run_gui.bat` → `launch_portable.bat` | `run_gui.bat` → `run_gui_source.bat` |
 | 首次依赖 | `setup_environment.py` | `install-cn.ps1` |
-| 默认打标模型 | 7z 内置 `tagger-models/wd14/wd14-convnextv2-v2/`，并保留 `huggingface/` 缓存兜底 | `install-cn.ps1` + 每次启动 `prefetch_default_tagger.py --if-missing` |
+| 默认打标模型 | 7z 内置 `tagger-models/wd14/wd14-convnextv2-v2/`，其它模型需联网从 Hugging Face 下载 | `install-cn.ps1` + 每次启动 `prefetch_default_tagger.py --if-missing` |
+| Hub 下载策略 | `MIKAZUKI_HUB_BACKEND=auto`（不强制魔搭）；内置 tokenizer/默认打标优先本地 | 源码 `auto`，按网络自动选择 |
+| 文件选择器 | 启动时把 `sd-models/`、`output/`、`logs/`、`train/` 联接进 `SD-Trainer/`（`link_portable_data_dirs.py`） | 数据目录本来就在项目根 |
+
+启动后**终端窗口**会显示打标模型下载进度与错误提示；不要关闭该窗口。
 
 ## 打标模型目录
 

--- a/scripts/portable/launch_portable.bat
+++ b/scripts/portable/launch_portable.bat
@@ -13,8 +13,8 @@ set "BASE_DIR=%PORTABLE_ROOT%"
 set "HF_HOME=%PORTABLE_ROOT%huggingface"
 set "MIKAZUKI_TAGGER_MODELS_DIR=%PORTABLE_ROOT%tagger-models"
 set "MIKAZUKI_TOKENIZER_CACHE_DIR=%PORTABLE_ROOT%tokenizer-cache"
-set "MIKAZUKI_HUB_BACKEND=modelscope"
-if not defined HF_ENDPOINT set "HF_ENDPOINT=https://hf-mirror.com"
+:: Bundled tagger-models/tokenizer-cache first; do not force ModelScope (WD taggers are HF-only).
+if not defined MIKAZUKI_HUB_BACKEND set "MIKAZUKI_HUB_BACKEND=auto"
 set "PYTHONUTF8=1"
 set "PYTHON_EXE=%PORTABLE_ROOT%python_embeded\python.exe"
 set "LOG_FILE=%PORTABLE_ROOT%sd-trainer-log.txt"
@@ -62,6 +62,11 @@ echo [setup] OK >> "%LOG_FILE%"
 cd /d "%PORTABLE_ROOT%SD-Trainer"
 if errorlevel 1 goto :no_project
 
+if exist "scripts\portable\link_portable_data_dirs.py" (
+    echo [portable] Linking sd-models/output/train into SD-Trainer for file picker >> "%LOG_FILE%"
+    "%PYTHON_EXE%" -s scripts\portable\link_portable_data_dirs.py >> "%LOG_FILE%" 2>&1
+)
+
 if exist "scripts\prefetch_default_tagger.py" (
     echo [tagger] Ensuring default WD tagger cache >> "%LOG_FILE%"
     "%PYTHON_EXE%" -s scripts\prefetch_default_tagger.py --if-missing --tagger-models-dir "%MIKAZUKI_TAGGER_MODELS_DIR%" >> "%LOG_FILE%" 2>&1
@@ -75,9 +80,10 @@ if exist "scripts\prefetch_sdxl_tokenizer.py" (
 echo [launch] Starting gui.py >> "%LOG_FILE%"
 echo.
 echo  Starting SD-Trainer...
+echo  运行日志（打标下载进度、错误信息等）将显示在本窗口。
 echo.
 
-"%PYTHON_EXE%" -s gui.py --skip-prepare-environment --port 28000 %* 2>> "%LOG_FILE%"
+"%PYTHON_EXE%" -s -u gui.py --skip-prepare-environment --port 28000 %*
 set "EXIT_CODE=%errorlevel%"
 echo [launch] gui.py exited with code %EXIT_CODE% >> "%LOG_FILE%"
 

--- a/tests/test_china_hub.py
+++ b/tests/test_china_hub.py
@@ -7,6 +7,7 @@ from mikazuki.china_hub import (
     HF_TO_MODELSCOPE_REPOS,
     enable_china_hub,
     hub_backend,
+    is_hf_only_repo,
     remap_hf_repo_id,
 )
 
@@ -29,6 +30,49 @@ def test_hub_backend_hf_mirror_endpoint(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("MIKAZUKI_HUB_BACKEND", "auto")
     monkeypatch.setenv("HF_ENDPOINT", "https://hf-mirror.com")
     assert hub_backend() == "modelscope"
+
+
+def test_smilingwolf_tagger_repos_are_hf_only():
+    assert is_hf_only_repo("SmilingWolf/wd-vit-large-tagger-v3")
+    assert is_hf_only_repo("cella110n/cl_tagger")
+    assert not is_hf_only_repo("openai/clip-vit-large-patch14")
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("modelscope") is None,
+    reason="modelscope not installed",
+)
+def test_smilingwolf_download_bypasses_modelscope_patch(monkeypatch: pytest.MonkeyPatch):
+    import mikazuki.china_hub as china_hub
+    import huggingface_hub
+
+    china_hub._PATCHED = False
+    china_hub._ORIGINAL_HF_HUB_DOWNLOAD = None
+    calls: list[tuple[tuple, dict]] = []
+
+    def fake_original(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "/tmp/model.onnx"
+
+    monkeypatch.setenv("MIKAZUKI_HUB_BACKEND", "modelscope")
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake_original)
+    import transformers  # noqa: F401 — patch_hub expects HF libs importable
+
+    try:
+        enabled = enable_china_hub(force=True)
+    except ImportError as exc:
+        pytest.skip(f"modelscope patch_hub unavailable in this env: {exc}")
+    if not enabled:
+        pytest.skip("modelscope not installed")
+
+    path = huggingface_hub.hf_hub_download(
+        repo_id="SmilingWolf/wd-vit-large-tagger-v3",
+        filename="model.onnx",
+    )
+    assert path == "/tmp/model.onnx"
+    assert len(calls) == 1
+    assert calls[0][1]["repo_id"] == "SmilingWolf/wd-vit-large-tagger-v3"
+    assert "HF_ENDPOINT" not in os.environ or os.environ.get("HF_ENDPOINT") != "https://hf-mirror.com"
 
 
 def test_enable_china_hub_requires_modelscope(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_portable_packaging_scripts.py
+++ b/tests/test_portable_packaging_scripts.py
@@ -33,15 +33,19 @@ def test_portable_builder_initializes_dataset_tag_editor_before_copy():
     assert "dataset-tag-editor\\scripts\\launch.py" in script
 
 
-def test_portable_launcher_keeps_default_hf_mirror_for_skip_prepare_mode():
+def test_portable_launcher_uses_auto_hub_backend_without_forcing_modelscope():
     launcher = (ROOT / "scripts" / "portable" / "launch_portable.bat").read_text(
         encoding="utf-8"
     )
 
-    assert "HF_ENDPOINT" in launcher
-    assert "https://hf-mirror.com" in launcher
+    assert "MIKAZUKI_HUB_BACKEND=auto" in launcher
+    assert "MIKAZUKI_HUB_BACKEND=modelscope" not in launcher
     assert "MIKAZUKI_TOKENIZER_CACHE_DIR" in launcher
     assert "prefetch_sdxl_tokenizer.py" in launcher
+    assert "-u gui.py" in launcher
+    assert 'gui.py --skip-prepare-environment' in launcher
+    gui_line = next(line for line in launcher.splitlines() if "gui.py" in line and "PYTHON_EXE" in line)
+    assert "2>>" not in gui_line
 
 
 def test_portable_builder_bundles_sdxl_tokenizer_cache():

--- a/tests/test_tagger_progress_api.py
+++ b/tests/test_tagger_progress_api.py
@@ -3,7 +3,11 @@
 from fastapi.testclient import TestClient
 
 from mikazuki.app.application import app
-from mikazuki.tagger.model_fetch import use_download_endpoint
+from mikazuki.tagger.model_fetch import (
+    describe_interrogator_asset_status,
+    format_tagger_download_error,
+    use_download_endpoint,
+)
 from mikazuki.tagger.progress import tagger_progress
 from mikazuki.tagger.interrogators.wd14 import WaifuDiffusionInterrogator
 from mikazuki.tagger.local_models import (
@@ -98,3 +102,36 @@ def test_tagger_assets_keep_legacy_flat_local_model_dir_compatible(tmp_path, mon
         model_dir / "model.onnx",
         model_dir / "selected_tags.csv",
     )
+
+
+def test_describe_interrogator_asset_status_reports_local_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
+    interrogator = WaifuDiffusionInterrogator(
+        "wd-vit-large-tagger-v3",
+        repo_id="SmilingWolf/wd-vit-large-tagger-v3",
+    )
+    ready, msg = describe_interrogator_asset_status("wd-vit-large-tagger-v3", interrogator)
+    assert ready is False
+    assert "未在本地" in msg
+    assert "tagger-models" in msg
+    assert "SmilingWolf/wd-vit-large-tagger-v3" in msg
+
+
+def test_format_tagger_download_error_network_hint():
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    hint = format_tagger_download_error(
+        "wd-vit-large-tagger-v3",
+        LocalEntryNotFoundError("Cannot find file"),
+    )
+    assert "huggingface.co" in hint
+    assert "未在本地" in hint
+
+
+def test_format_tagger_download_error_modelscope_404():
+    hint = format_tagger_download_error(
+        "wd-vit-large-tagger-v3",
+        Exception("Repo SmilingWolf/wd-vit-large-tagger-v3 not exists on modelscope.cn"),
+    )
+    assert "魔搭" in hint
+    assert "SmilingWolf" in hint


### PR DESCRIPTION
MIKAZUKI_HUB_BACKEND=auto, SmilingWolf HF fallback, tagger terminal progress. No frontend.

Tests: pytest tests/test_china_hub.py tests/test_tagger_progress_api.py

Made with [Cursor](https://cursor.com)