### PR TITLE
fix(tagger): load detected local models without network

### DIFF
--- a/mikazuki/tagger/interrogator.py
+++ b/mikazuki/tagger/interrogator.py
@@ -32,8 +32,9 @@ available_interrogators = {
         repo_id='SmilingWolf/wd-swinv2-tagger-v3',
     ),
     'wd-vit-v3': WaifuDiffusionInterrogator(
-        'wd14-vit-v3',
+        'wd-vit-v3',
         repo_id='SmilingWolf/wd-vit-tagger-v3',
+        local_model_aliases=('wd14-vit-v3',),
     ),
     'wd14-convnextv2-v2': WaifuDiffusionInterrogator(
         'wd14-convnextv2-v2', repo_id='SmilingWolf/wd-v1-4-convnextv2-tagger-v2',
@@ -48,9 +49,10 @@ available_interrogators = {
         revision='v2.0'
     ),
     'wd14-moat-v2': WaifuDiffusionInterrogator(
-        'wd-v1-4-moat-tagger-v2',
+        'wd14-moat-v2',
         repo_id='SmilingWolf/wd-v1-4-moat-tagger-v2',
-        revision='v2.0'
+        revision='v2.0',
+        local_model_aliases=('wd-v1-4-moat-tagger-v2',),
     ),
     'wd-eva02-large-tagger-v3': WaifuDiffusionInterrogator(
         'wd-eva02-large-tagger-v3',

--- a/mikazuki/tagger/interrogators/wd14.py
+++ b/mikazuki/tagger/interrogators/wd14.py
@@ -24,20 +24,38 @@ class WaifuDiffusionInterrogator(Interrogator):
             name: str,
             model_path='model.onnx',
             tags_path='selected_tags.csv',
+            local_model_aliases: tuple[str, ...] = (),
             **kwargs
     ) -> None:
         super().__init__(name)
         self.model_path = model_path
         self.tags_path = tags_path
+        self.local_model_aliases = tuple(local_model_aliases)
         self.kwargs = kwargs
 
     def download(self) -> Tuple[os.PathLike, os.PathLike]:
-        local_paths = local_model_asset_paths(self.name, self)
-        if local_paths:
-            print(f"Loading {self.name} model from local tagger-models directory")
-            return local_paths
+        for model_key in (self.name, *self.local_model_aliases):
+            local_paths = local_model_asset_paths(model_key, self)
+            if local_paths:
+                print(
+                    f"Loading {self.name} model from local tagger-models "
+                    f"directory ({model_key})"
+                )
+                return local_paths
 
         repo_id = self.kwargs["repo_id"]
+        cache_kwargs = dict(self.kwargs)
+        cache_kwargs["local_files_only"] = True
+        try:
+            model_path = Path(hf_hub_download(
+                **cache_kwargs, filename=self.model_path))
+            tags_path = Path(hf_hub_download(
+                **cache_kwargs, filename=self.tags_path))
+            print(f"Loading {self.name} model from local Hugging Face cache")
+            return model_path, tags_path
+        except Exception:
+            pass
+
         print(f"Loading {self.name} model from {repo_id} (first run may download ~400MB, see console log)")
 
         model_path = Path(hf_hub_download(

--- a/mikazuki/tagger/model_fetch.py
+++ b/mikazuki/tagger/model_fetch.py
@@ -64,6 +64,10 @@ def describe_interrogator_asset_status(
     files = _asset_filenames(interrogator)
     local_dir = local_model_dir(model_key)
     missing = [name for name in files if not _file_cached(kwargs, name)]
+    if files and not missing:
+        return True, (
+            f"[tagger] 模型 {model_key} 已在 Hugging Face 本地缓存: {repo_id}"
+        )
     file_hint = ", ".join(missing or files)
     return False, (
         f"[tagger] 模型 {model_key} 未在本地\n"

--- a/tests/test_tagger_progress_api.py
+++ b/tests/test_tagger_progress_api.py
@@ -3,11 +3,14 @@
 from fastapi.testclient import TestClient
 
 from mikazuki.app.application import app
+from mikazuki.tagger import model_fetch as model_fetch_module
 from mikazuki.tagger.model_fetch import (
     describe_interrogator_asset_status,
     format_tagger_download_error,
     use_download_endpoint,
 )
+from mikazuki.tagger.interrogator import available_interrogators
+from mikazuki.tagger.interrogators import wd14 as wd14_module
 from mikazuki.tagger.progress import tagger_progress
 from mikazuki.tagger.interrogators.wd14 import WaifuDiffusionInterrogator
 from mikazuki.tagger.local_models import (
@@ -85,6 +88,130 @@ def test_tagger_assets_ready_when_files_exist_in_wd14_local_model_dir(tmp_path, 
     )
 
 
+def test_wd_vit_v3_download_uses_the_same_local_directory_as_asset_precheck(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
+    model_dir = tmp_path / "tagger-models" / "wd14" / "wd-vit-v3"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.onnx").write_bytes(b"fake onnx")
+    (model_dir / "selected_tags.csv").write_text("name,category\n", encoding="utf-8")
+
+    def fail_if_huggingface_is_called(**_kwargs):
+        raise AssertionError("local wd-vit-v3 assets must not contact Hugging Face")
+
+    monkeypatch.setattr(wd14_module, "hf_hub_download", fail_if_huggingface_is_called)
+    interrogator = available_interrogators["wd-vit-v3"]
+
+    assert local_model_asset_paths("wd-vit-v3", interrogator) == (
+        model_dir / "model.onnx",
+        model_dir / "selected_tags.csv",
+    )
+    assert interrogator.download() == (
+        model_dir / "model.onnx",
+        model_dir / "selected_tags.csv",
+    )
+
+
+def test_wd14_moat_v2_download_uses_the_same_local_directory_as_asset_precheck(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
+    model_dir = tmp_path / "tagger-models" / "wd14" / "wd14-moat-v2"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.onnx").write_bytes(b"fake onnx")
+    (model_dir / "selected_tags.csv").write_text("name,category\n", encoding="utf-8")
+
+    def fail_if_huggingface_is_called(**_kwargs):
+        raise AssertionError("local wd14-moat-v2 assets must not contact Hugging Face")
+
+    monkeypatch.setattr(wd14_module, "hf_hub_download", fail_if_huggingface_is_called)
+    interrogator = available_interrogators["wd14-moat-v2"]
+
+    assert local_model_asset_paths("wd14-moat-v2", interrogator) == (
+        model_dir / "model.onnx",
+        model_dir / "selected_tags.csv",
+    )
+    assert interrogator.download() == (
+        model_dir / "model.onnx",
+        model_dir / "selected_tags.csv",
+    )
+
+
+def test_renamed_wd_models_keep_their_previous_local_directory_compatible(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
+
+    def fail_if_huggingface_is_called(**_kwargs):
+        raise AssertionError("legacy local model directories must remain offline")
+
+    monkeypatch.setattr(wd14_module, "hf_hub_download", fail_if_huggingface_is_called)
+
+    for model_key, previous_name in (
+        ("wd-vit-v3", "wd14-vit-v3"),
+        ("wd14-moat-v2", "wd-v1-4-moat-tagger-v2"),
+    ):
+        model_dir = tmp_path / "tagger-models" / "wd14" / previous_name
+        model_dir.mkdir(parents=True)
+        (model_dir / "model.onnx").write_bytes(b"fake onnx")
+        (model_dir / "selected_tags.csv").write_text(
+            "name,category\n", encoding="utf-8"
+        )
+
+        assert available_interrogators[model_key].download() == (
+            model_dir / "model.onnx",
+            model_dir / "selected_tags.csv",
+        )
+
+
+def test_wd14_download_uses_complete_huggingface_cache_without_network(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
+    cached_model = tmp_path / "huggingface-cache" / "model.onnx"
+    cached_tags = tmp_path / "huggingface-cache" / "selected_tags.csv"
+    cached_model.parent.mkdir(parents=True)
+    cached_model.write_bytes(b"fake onnx")
+    cached_tags.write_text("name,category\n", encoding="utf-8")
+    calls = []
+
+    def cached_hf_download(**kwargs):
+        calls.append(kwargs)
+        assert kwargs.get("local_files_only") is True
+        return cached_model if kwargs["filename"] == "model.onnx" else cached_tags
+
+    monkeypatch.setattr(wd14_module, "hf_hub_download", cached_hf_download)
+    interrogator = WaifuDiffusionInterrogator(
+        "wd-vit-v3",
+        repo_id="SmilingWolf/wd-vit-tagger-v3",
+    )
+
+    assert interrogator.download() == (cached_model, cached_tags)
+    assert [call["filename"] for call in calls] == [
+        "model.onnx",
+        "selected_tags.csv",
+    ]
+
+
+def test_describe_interrogator_asset_status_reports_complete_hf_cache(monkeypatch):
+    monkeypatch.setattr(
+        model_fetch_module,
+        "_file_cached",
+        lambda _kwargs, _filename: True,
+    )
+    interrogator = WaifuDiffusionInterrogator(
+        "wd-vit-v3",
+        repo_id="SmilingWolf/wd-vit-tagger-v3",
+    )
+
+    ready, message = describe_interrogator_asset_status("wd-vit-v3", interrogator)
+
+    assert ready is True
+    assert "Hugging Face 本地缓存" in message
+    assert "未在本地" not in message
+
+
 def test_tagger_assets_keep_legacy_flat_local_model_dir_compatible(tmp_path, monkeypatch):
     monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
     model_dir = tmp_path / "tagger-models" / "wd14-convnextv2-v2"
@@ -106,6 +233,11 @@ def test_tagger_assets_keep_legacy_flat_local_model_dir_compatible(tmp_path, mon
 
 def test_describe_interrogator_asset_status_reports_local_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("MIKAZUKI_TAGGER_MODELS_DIR", str(tmp_path / "tagger-models"))
+    monkeypatch.setattr(
+        model_fetch_module,
+        "_file_cached",
+        lambda _kwargs, _filename: False,
+    )
     interrogator = WaifuDiffusionInterrogator(
         "wd-vit-large-tagger-v3",
         repo_id="SmilingWolf/wd-vit-large-tagger-v3",


### PR DESCRIPTION
## Summary
- 统一 `wd-vit-v3`、`wd14-moat-v2` 的模型键与本地目录查找，检测到 `tagger-models` 资产后直接离线加载
- 保留旧内部目录名作为兼容别名，避免已有模型副本失效
- 优先以 `local_files_only` 读取完整 Hugging Face 缓存，缓存命中时不再发起网络 HEAD/重试
- 补充本地目录、旧目录别名和 HF 缓存的回归测试

## Test plan
- [x] `python -m pytest tests/test_tagger_progress_api.py tests/test_tagger_ort_session.py -q`
- [x] `python -m pytest tests/test_china_hub.py -q`
- [x] IDE lint：无新增错误

Closes wochenlong/lora-scripts-next#194