### PR TITLE
fix(anima-fast): support resolutions above 1024

### DIFF
--- a/mikazuki/anima_fast_backend/adapter.py
+++ b/mikazuki/anima_fast_backend/adapter.py
@@ -152,7 +152,7 @@ def resolution_pair(value: Any, default: int = 1024) -> list[int]:
 
 
 def normalize_bucket_resolution(values: dict[str, Any], warnings: list[str]) -> None:
-    if not truthy(values.get("enable_bucket", True)) or truthy(values.get("bucket_no_upscale")):
+    if not truthy(values.get("enable_bucket", True)):
         return
 
     width, height = resolution_pair(values.get("resolution"))

--- a/mikazuki/anima_fast_backend/adapter.py
+++ b/mikazuki/anima_fast_backend/adapter.py
@@ -151,6 +151,42 @@ def resolution_pair(value: Any, default: int = 1024) -> list[int]:
     return [default, default]
 
 
+def normalize_bucket_resolution(values: dict[str, Any], warnings: list[str]) -> None:
+    if not truthy(values.get("enable_bucket", True)) or truthy(values.get("bucket_no_upscale")):
+        return
+
+    width, height = resolution_pair(values.get("resolution"))
+    required_max = max(width, height)
+    bucket_step = int_value(values.get("bucket_reso_steps"), 64)
+    if bucket_step <= 0:
+        raise AdapterError("bucket_reso_steps must be greater than 0")
+
+    configured_max = int_value(values.get("max_bucket_reso"), 0)
+    if configured_max <= 0:
+        effective_max = max(1024, required_max)
+        effective_max = ((effective_max + bucket_step - 1) // bucket_step) * bucket_step
+        values["max_bucket_reso"] = effective_max
+        if effective_max > 1024:
+            warnings.append(
+                f"max_bucket_reso 未设置，已按 resolution 自动设为 {effective_max}"
+            )
+        return
+
+    effective_max = ((configured_max + bucket_step - 1) // bucket_step) * bucket_step
+    if effective_max < required_max:
+        resolution_text = str(values.get("resolution", f"{width},{height}"))
+        raise AdapterError(
+            f"max_bucket_reso={configured_max} 小于 resolution={resolution_text}；"
+            f"请设置为至少 {required_max}，或留空自动计算"
+        )
+    if effective_max != configured_max:
+        values["max_bucket_reso"] = effective_max
+        warnings.append(
+            f"max_bucket_reso 已按 bucket_reso_steps 从 {configured_max} "
+            f"向上调整为 {effective_max}"
+        )
+
+
 def normalize_kv_args(values: Any) -> list[str]:
     if not isinstance(values, list):
         return []
@@ -333,6 +369,8 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
         if repeats > 0:
             values["dataset_repeats"] = repeats
             break
+
+    normalize_bucket_resolution(values, warnings)
 
     values.setdefault("torch_compile", True)
     values.setdefault("static_token_count", 4096)

--- a/mikazuki/schema/anima-lora-fast.ts
+++ b/mikazuki/schema/anima-lora-fast.ts
@@ -33,6 +33,10 @@ Schema.intersect([
         caption_extension: Schema.string().default(".txt").description("caption 后缀"),
         resolution: Schema.string().default("1024,1024").description("训练图片分辨率"),
         enable_bucket: Schema.boolean().default(true).description("启用 arb 桶"),
+        min_bucket_reso: Schema.number().min(64).step(64).default(256).description("arb 桶最小分辨率"),
+        max_bucket_reso: Schema.number().min(64).step(64).description("arb 桶最大分辨率；留空时按训练分辨率自动设置，也可以手动填写更大的值"),
+        bucket_reso_steps: Schema.number().min(1).step(1).default(64).description("arb 桶分辨率划分单位"),
+        bucket_no_upscale: Schema.boolean().default(false).description("不放大较小图片；开启后 min/max bucket 限制由训练器忽略"),
     }).description("数据集设置"),
 
     SHARED_SCHEMAS.SAVE_SETTINGS,

--- a/mikazuki/schema/anima-lora-fast.ts
+++ b/mikazuki/schema/anima-lora-fast.ts
@@ -36,7 +36,7 @@ Schema.intersect([
         min_bucket_reso: Schema.number().min(64).step(64).default(256).description("arb 桶最小分辨率"),
         max_bucket_reso: Schema.number().min(64).step(64).description("arb 桶最大分辨率；留空时按训练分辨率自动设置，也可以手动填写更大的值"),
         bucket_reso_steps: Schema.number().min(1).step(1).default(64).description("arb 桶分辨率划分单位"),
-        bucket_no_upscale: Schema.boolean().default(false).description("不放大较小图片；开启后 min/max bucket 限制由训练器忽略"),
+        bucket_no_upscale: Schema.boolean().default(false).description("不放大较小图片；max bucket 仍需覆盖训练分辨率"),
     }).description("数据集设置"),
 
     SHARED_SCHEMAS.SAVE_SETTINGS,

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -350,7 +350,7 @@ class AdapterTests(unittest.TestCase):
         self.assertEqual(adapted.values["max_bucket_reso"], 1600)
         self.assertTrue(any("1550" in warning and "1600" in warning for warning in adapted.warnings))
 
-    def test_adapt_config_allows_smaller_bucket_limit_when_no_upscale_is_enabled(self):
+    def test_adapt_config_derives_bucket_limit_when_no_upscale_is_enabled(self):
         with tempfile.TemporaryDirectory() as td:
             runtime = make_runtime(Path(td))
             adapted = adapt_config({
@@ -358,10 +358,9 @@ class AdapterTests(unittest.TestCase):
                 "resolution": "1536,1536",
                 "enable_bucket": True,
                 "bucket_no_upscale": True,
-                "max_bucket_reso": 1024,
             }, runtime, "run-1")
 
-        self.assertEqual(adapted.values["max_bucket_reso"], 1024)
+        self.assertEqual(adapted.values["max_bucket_reso"], 1536)
 
     def test_adapt_config_ignores_unsupported_fast_memory_fields(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -296,6 +296,73 @@ class AdapterTests(unittest.TestCase):
         self.assertEqual(adapted.values["static_token_count"], 9216)
         self.assertTrue(any("static_token_count" in warning for warning in adapted.warnings))
 
+    def test_adapt_config_derives_max_bucket_reso_for_high_resolution(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            adapted = adapt_config({
+                "lora_type": "lora",
+                "resolution": "1536,1536",
+                "enable_bucket": True,
+            }, runtime, "run-1")
+
+        self.assertEqual(adapted.values["max_bucket_reso"], 1536)
+        self.assertTrue(any("max_bucket_reso" in warning for warning in adapted.warnings))
+        self.assertIn("max_bucket_reso = 1536", dump_fast_dataset_toml(adapted.values))
+
+    def test_adapt_config_preserves_valid_user_max_bucket_reso(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            adapted = adapt_config({
+                "lora_type": "lora",
+                "resolution": "1536,1536",
+                "enable_bucket": True,
+                "max_bucket_reso": 2048,
+            }, runtime, "run-1")
+
+        self.assertEqual(adapted.values["max_bucket_reso"], 2048)
+        self.assertFalse(any("max_bucket_reso" in warning for warning in adapted.warnings))
+
+    def test_adapt_config_rejects_max_bucket_reso_below_resolution(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            with self.assertRaisesRegex(
+                AdapterError,
+                "max_bucket_reso=1024.*resolution=1536,1536",
+            ):
+                adapt_config({
+                    "lora_type": "lora",
+                    "resolution": "1536,1536",
+                    "enable_bucket": True,
+                    "max_bucket_reso": 1024,
+                }, runtime, "run-1")
+
+    def test_adapt_config_rounds_max_bucket_reso_to_bucket_step(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            adapted = adapt_config({
+                "lora_type": "lora",
+                "resolution": "1536,1536",
+                "enable_bucket": True,
+                "max_bucket_reso": 1550,
+                "bucket_reso_steps": 64,
+            }, runtime, "run-1")
+
+        self.assertEqual(adapted.values["max_bucket_reso"], 1600)
+        self.assertTrue(any("1550" in warning and "1600" in warning for warning in adapted.warnings))
+
+    def test_adapt_config_allows_smaller_bucket_limit_when_no_upscale_is_enabled(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            adapted = adapt_config({
+                "lora_type": "lora",
+                "resolution": "1536,1536",
+                "enable_bucket": True,
+                "bucket_no_upscale": True,
+                "max_bucket_reso": 1024,
+            }, runtime, "run-1")
+
+        self.assertEqual(adapted.values["max_bucket_reso"], 1024)
+
     def test_adapt_config_ignores_unsupported_fast_memory_fields(self):
         with tempfile.TemporaryDirectory() as td:
             runtime = make_runtime(Path(td))

--- a/tests/test_anima_fast_integration_static.py
+++ b/tests/test_anima_fast_integration_static.py
@@ -21,6 +21,15 @@ class AnimaFastStaticIntegrationTests(unittest.TestCase):
         self.assertIn('"EmoSens"', shared[: shared.index("ANIMA_FAST_LR_OPTIMIZER")])
         self.assertIn('Schema.const("lora")', schema)
 
+    def test_fast_schema_exposes_bucket_resolution_controls(self):
+        schema = Path("mikazuki/schema/anima-lora-fast.ts").read_text(encoding="utf-8")
+
+        self.assertIn("min_bucket_reso:", schema)
+        self.assertIn("max_bucket_reso:", schema)
+        self.assertIn("bucket_reso_steps:", schema)
+        self.assertIn("bucket_no_upscale:", schema)
+        self.assertIn("留空时按训练分辨率自动设置", schema)
+
     def test_fast_adapter_does_not_whitelist_emosens(self):
         adapter = Path("mikazuki/anima_fast_backend/adapter.py").read_text(encoding="utf-8")
         self.assertIn("FAST_SUPPORTED_OPTIMIZERS", adapter)


### PR DESCRIPTION
## Summary
- ? Anima Fast ??????????/?????????????????
- `max_bucket_reso` ??????????????????1536?1536 ??? 1536
- ????????????????????????????????????
- ?????????????????????? `bucket_no_upscale` ????

## Test plan
- [x] `python -m pytest tests/test_anima_fast_backend.py -q`?42 passed?
- [x] Fast Schema ?????2 passed?
- [x] IDE lint??????

Closes wochenlong/lora-scripts-next#196
