### PR TITLE
fix(anima-fast): use Windows certs for installer downloads

### DIFF
--- a/docs/anima-fast.md
+++ b/docs/anima-fast.md
@@ -294,6 +294,7 @@ Fast 页优化器下拉**仅列出当前 anima_lora 插件快照已支持的选�
 |------|------|
 | 状态「进阶插件 · 待开启」 | 运行 `scripts/cli/install_anima_fast.*` 安装（推荐，终端可见报错）；或在页内点「开启插件」 |
 | 安装失败 / 审计失败 | 优先用 CLI 脚本重装看终端报错；亦可看页内日志或 `POST /api/plugins/anima-lora/repair` |
+| `invalid peer certificate: UnknownIssuer` | Windows 安装器会默认使用系统证书库；若仍失败，请确认代理或杀毒软件的根证书已受 Windows 信任，也可换网络重试。旧版 uv 可在安装前设置 `$env:UV_NATIVE_TLS="true"` |
 | `No bitsandbytes` / 优化器 ImportError | 修复插件；或确认 `optimizer_type=AdamW` 临时绕过 |
 | 末 epoch 报 accelerate / `NoneType is not iterable` | torch 的 `.dist-info` 损坏；**修复插件** 或重装 `torch==2.11.0+cu130` |
 | 训练按钮灰色 | 插件未就绪；先安装 |

--- a/mikazuki/anima_fast_backend/environment.py
+++ b/mikazuki/anima_fast_backend/environment.py
@@ -310,6 +310,12 @@ def _run_streaming_once(command: list[str], cwd: Path, log: LogFn, env: dict[str
     merged_env = os.environ.copy()
     if env:
         merged_env.update(env)
+    if (
+        sys.platform == "win32"
+        and "UV_SYSTEM_CERTS" not in merged_env
+        and "UV_NATIVE_TLS" not in merged_env
+    ):
+        merged_env["UV_SYSTEM_CERTS"] = "true"
     merged_env.update({
         "PYTHONIOENCODING": "utf-8",
         "PYTHONUNBUFFERED": "1",
@@ -333,11 +339,23 @@ def _run_streaming_once(command: list[str], cwd: Path, log: LogFn, env: dict[str
         bufsize=1,
     )
     assert completed.stdout is not None
+    unknown_certificate_issuer = False
     for line in iter(completed.stdout.readline, ""):
-        _append(log, line.rstrip("\r\n"))
+        clean_line = line.rstrip("\r\n")
+        if "unknownissuer" in clean_line.lower():
+            unknown_certificate_issuer = True
+        _append(log, clean_line)
     returncode = completed.wait()
     _append(log, f"[exit] returncode={returncode}")
     if returncode != 0:
+        if unknown_certificate_issuer:
+            _append(log, "[hint] HTTPS certificate verification failed (UnknownIssuer).")
+            _append(
+                log,
+                "[hint] Windows: ensure the proxy or antivirus root CA is trusted; "
+                "the installer enables UV_SYSTEM_CERTS=true by default.",
+            )
+            _append(log, "[hint] For older uv versions, set UV_NATIVE_TLS=true before retrying.")
         raise subprocess.CalledProcessError(returncode, command)
 
 

--- a/tests/test_anima_fast_environment_installer.py
+++ b/tests/test_anima_fast_environment_installer.py
@@ -407,6 +407,64 @@ class AnimaFastEnvironmentInstallerTests(unittest.TestCase):
 
         self.assertEqual(captured["env"].get("HF_ENDPOINT"), "https://modelscope.cn")
 
+    def test_install_streaming_uses_windows_system_certificates_by_default(self):
+        from mikazuki.anima_fast_backend.environment import _run_streaming_once
+
+        captured: dict = {}
+
+        class _FakeStdout:
+            def readline(self):
+                return ""
+
+        class _FakeProc:
+            def __init__(self, *a, **k):
+                self.stdout = _FakeStdout()
+                captured["env"] = k.get("env")
+
+            def wait(self):
+                return 0
+
+        env_without_uv_certs = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"UV_SYSTEM_CERTS", "UV_NATIVE_TLS"}
+        }
+        with tempfile.TemporaryDirectory() as td, \
+            mock.patch("mikazuki.anima_fast_backend.environment.subprocess.Popen", _FakeProc), \
+            mock.patch("mikazuki.anima_fast_backend.environment.sys.platform", "win32"), \
+            mock.patch.dict("os.environ", env_without_uv_certs, clear=True):
+            _run_streaming_once(["uv", "pip", "install"], Path(td), lambda _line: None)
+
+        self.assertEqual(captured["env"].get("UV_SYSTEM_CERTS"), "true")
+
+    def test_install_streaming_explains_unknown_certificate_issuer(self):
+        from mikazuki.anima_fast_backend.environment import _run_streaming_once
+
+        lines = iter([
+            "error sending request for url\n",
+            "invalid peer certificate: UnknownIssuer\n",
+        ])
+
+        class _FakeStdout:
+            def readline(self):
+                return next(lines, "")
+
+        class _FakeProc:
+            def __init__(self, *a, **k):
+                self.stdout = _FakeStdout()
+
+            def wait(self):
+                return 1
+
+        logs: list[str] = []
+        with tempfile.TemporaryDirectory() as td, \
+            mock.patch("mikazuki.anima_fast_backend.environment.subprocess.Popen", _FakeProc):
+            with self.assertRaises(subprocess.CalledProcessError):
+                _run_streaming_once(["uv", "pip", "install"], Path(td), logs.append)
+
+        self.assertTrue(any("UV_SYSTEM_CERTS=true" in line for line in logs))
+        self.assertTrue(any("HTTPS" in line and "certificate" in line for line in logs))
+
     def test_audit_environment_skips_triton_windows_on_linux(self):
         with tempfile.TemporaryDirectory() as td, mock.patch(
             "mikazuki.anima_fast_backend.environment.sys.platform", "linux"


### PR DESCRIPTION
## Summary
- Windows ?? Anima Fast ?? uv ????????????????????????????
- ?? `UV_SYSTEM_CERTS` / `UV_NATIVE_TLS` ????????????
- ??? `UnknownIssuer` ??????????????? uv ????
- ? Fast ????????????????

## Test plan
- [x] `python -m pytest tests/test_anima_fast_environment_installer.py -q`?26 passed?
- [x] IDE lint??????

Closes wochenlong/lora-scripts-next#195
