### PR TITLE
fix(portable): avoid duplicating junction data in 7z

### DIFF
--- a/build-scripts/build_portable.ps1
+++ b/build-scripts/build_portable.ps1
@@ -738,8 +738,18 @@ if (-not $Skip7z) {
         $archivePath = Join-Path $buildDir $archiveName
         if (Test-Path $archivePath) { Remove-Item $archivePath -Force }
 
+        # 7-Zip follows Windows directory junctions. These paths point back to
+        # portable-root data directories, so archiving them would duplicate
+        # large assets such as the bundled WD14 ONNX model.
+        $archiveExcludes = @(
+            "-xr!SD-Trainer\sd-models",
+            "-xr!SD-Trainer\output",
+            "-xr!SD-Trainer\logs",
+            "-xr!SD-Trainer\train",
+            "-xr!SD-Trainer\tagger-models"
+        )
         Write-Host "  Compressing..."
-        & $7zExe a -t7z -mx=9 -m0=LZMA2:d=64m -mmt=on $archivePath "$portableDir\*" | Out-Null
+        & $7zExe a -t7z -mx=9 -m0=LZMA2:d=64m -mmt=on $archivePath "$portableDir\*" @archiveExcludes | Out-Null
 
         $sizeBytes = (Get-Item $archivePath).Length
         $sizeMB = [math]::Round($sizeBytes / 1MB, 1)

--- a/tests/test_portable_packaging_scripts.py
+++ b/tests/test_portable_packaging_scripts.py
@@ -73,6 +73,15 @@ def test_portable_builder_bundles_visible_tagger_models_directory():
     assert "MIKAZUKI_TAGGER_MODELS_DIR" in launcher
 
 
+def test_portable_archive_excludes_trainer_data_junctions():
+    script = (ROOT / "build-scripts" / "build_portable.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    for name in ("sd-models", "output", "logs", "train", "tagger-models"):
+        assert f"-xr!SD-Trainer\\{name}" in script
+
+
 def test_portable_builder_bundles_dual_update_scripts():
     script = (ROOT / "build-scripts" / "build_portable.ps1").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary
- ?? 7z ??? `SD-Trainer/` ????????????? junction
- ???? WD14 ????????? junction ??????
- ???????????????????????? junction

## Test plan
- [x] `python -m pytest tests/test_portable_packaging_scripts.py -q`?13 passed?
- [x] ???????????`model.onnx` ??? 2 ??? 1 ?
- [x] ????????? 731 MB ??? 408 MB
