### PR TITLE
feat(musubi): Krea2 multi-GPU via accelerate launch

### DIFF
--- a/mikazuki/musubi_backend/launcher.py
+++ b/mikazuki/musubi_backend/launcher.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 import os
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 runtime
+    import toml as tomllib  # type: ignore
 
 from .settings import RuntimeConfig
+
+_VALID_ACCELERATE_MIXED_PRECISION = {"no", "fp16", "bf16", "fp8"}
 
 
 @dataclass
@@ -12,6 +20,36 @@ class LaunchSpec:
     command: list[str]
     cwd: Path
     env: dict[str, str]
+
+
+def _normalize_mixed_precision(value: object) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized or normalized in {"none", "null"}:
+        return None
+    if normalized in _VALID_ACCELERATE_MIXED_PRECISION:
+        return normalized
+    return None
+
+
+def _read_mixed_precision_from_train_toml(train_toml: Path) -> str | None:
+    if not train_toml.is_file():
+        return None
+    try:
+        data = tomllib.loads(train_toml.read_text(encoding="utf-8"))
+    except OSError:
+        return None
+    if not data:
+        return None
+    return _normalize_mixed_precision(data.get("mixed_precision"))
+
+
+def _first_gpu_only(gpu_ids: list[str] | None) -> list[str] | None:
+    """Cache stages stay single-process; pin to the first selected GPU."""
+    if not gpu_ids:
+        return None
+    return [str(gpu_ids[0])]
 
 
 def _base_env(runtime: RuntimeConfig, task_id: str, gpu_ids: list[str] | None = None) -> dict[str, str]:
@@ -34,7 +72,7 @@ def _base_env(runtime: RuntimeConfig, task_id: str, gpu_ids: list[str] | None = 
     if runtime.hf_home is not None:
         env["HF_HOME"] = str(runtime.hf_home)
     if gpu_ids:
-        env["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_ids)
+        env["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_ids)
     return env
 
 
@@ -56,7 +94,11 @@ def build_cache_latents_spec(
     ]
     if skip_existing:
         command.append("--skip_existing")
-    return LaunchSpec(command=command, cwd=runtime.musubi_root, env=_base_env(runtime, task_id, gpu_ids))
+    return LaunchSpec(
+        command=command,
+        cwd=runtime.musubi_root,
+        env=_base_env(runtime, task_id, _first_gpu_only(gpu_ids)),
+    )
 
 
 def build_cache_text_encoder_spec(
@@ -77,7 +119,11 @@ def build_cache_text_encoder_spec(
     ]
     if skip_existing:
         command.append("--skip_existing")
-    return LaunchSpec(command=command, cwd=runtime.musubi_root, env=_base_env(runtime, task_id, gpu_ids))
+    return LaunchSpec(
+        command=command,
+        cwd=runtime.musubi_root,
+        env=_base_env(runtime, task_id, _first_gpu_only(gpu_ids)),
+    )
 
 
 def build_train_spec(
@@ -85,11 +131,43 @@ def build_train_spec(
     train_toml: Path,
     task_id: str,
     gpu_ids: list[str] | None = None,
+    *,
+    cpu_threads: int = 1,
 ) -> LaunchSpec:
+    """Build musubi Krea2 train argv via ``accelerate launch`` (multi-GPU capable).
+
+    Upstream musubi-tuner documents ``accelerate launch … krea2_train_network.py``.
+    We use the musubi venv's ``python -m accelerate.commands.launch`` so the
+    correct Accelerate/Torch stack is used (not the Kohya/main env).
+    """
+    script = runtime.musubi_root / "krea2_train_network.py"
+    launch_opts = [
+        "--num_cpu_threads_per_process",
+        str(cpu_threads),
+        "--quiet",
+    ]
+    mixed_precision = _read_mixed_precision_from_train_toml(train_toml)
+    if mixed_precision:
+        launch_opts.extend(["--mixed_precision", mixed_precision])
+
+    multi_gpu_args: list[str] = []
+    env = _base_env(runtime, task_id, gpu_ids)
+    env["ACCELERATE_DISABLE_RICH"] = "1"
+
+    if gpu_ids and len(gpu_ids) > 1:
+        multi_gpu_args = ["--multi_gpu", "--num_processes", str(len(gpu_ids))]
+        if sys.platform == "win32":
+            env["USE_LIBUV"] = "0"
+            multi_gpu_args = ["--rdzv_backend", "c10d", *multi_gpu_args]
+
     command = [
         str(runtime.python),
-        str(runtime.musubi_root / "krea2_train_network.py"),
+        "-m",
+        "accelerate.commands.launch",
+        *multi_gpu_args,
+        *launch_opts,
+        str(script),
         "--config_file",
         str(train_toml),
     ]
-    return LaunchSpec(command=command, cwd=runtime.musubi_root, env=_base_env(runtime, task_id, gpu_ids))
+    return LaunchSpec(command=command, cwd=runtime.musubi_root, env=env)

--- a/mikazuki/process.py
+++ b/mikazuki/process.py
@@ -303,6 +303,15 @@ def run_musubi_train(toml_path: str,
     from mikazuki.tasks import TaskStatus
 
     log.info(f"musubi-tuner training started with config file / musubi 训练开始，使用配置文件: {toml_path}")
+    if gpu_ids:
+        log.info(f"Using GPU(s) / 使用 GPU: {gpu_ids}")
+        if len(gpu_ids) > 1:
+            log.info(
+                "Musubi train will use accelerate --multi_gpu; cache stages stay on GPU %s / "
+                "训练阶段多卡，缓存阶段仍用 GPU %s",
+                gpu_ids[0],
+                gpu_ids[0],
+            )
     patch_krea2_tokenizer_path(runtime.musubi_root, krea2_tokenizer_dir(runtime.lora_next_root), log=log.info)
     train_task_id = str(uuid.uuid4())
     dataset_toml = Path(str(values["dataset_config"]))

--- a/tests/test_musubi_backend.py
+++ b/tests/test_musubi_backend.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -225,6 +227,7 @@ class LauncherTests(unittest.TestCase):
             runtime = make_runtime(root)
             dataset_toml = root / "d.toml"
             train_toml = root / "t.toml"
+            train_toml.write_text('mixed_precision = "bf16"\n', encoding="utf-8")
 
             latents = build_cache_latents_spec(runtime, dataset_toml, "/models/vae.safetensors", "task-cache_latents", ["0"])
             te = build_cache_text_encoder_spec(runtime, dataset_toml, "/models/te.safetensors", "task-cache_text_encoder")
@@ -234,17 +237,59 @@ class LauncherTests(unittest.TestCase):
             self.assertEqual(spec.command[0], str(runtime.python))
             self.assertEqual(spec.cwd, runtime.musubi_root)
             self.assertEqual(spec.env["PYTHONNOUSERSITE"], "1")
-            self.assertIn(str((runtime.musubi_root / "src").resolve()), spec.env["PYTHONPATH"].split(";"))
+            self.assertIn(str((runtime.musubi_root / "src").resolve()), spec.env["PYTHONPATH"].split(os.pathsep))
 
         self.assertIn("krea2_cache_latents.py", latents.command[1])
         self.assertIn("--skip_existing", latents.command)
         self.assertIn("--vae", latents.command)
         self.assertIn("krea2_cache_text_encoder_outputs.py", te.command[1])
         self.assertIn("--text_encoder", te.command)
-        self.assertIn("krea2_train_network.py", train.command[1])
-        self.assertEqual(train.command[-1], str(train_toml))
+        self.assertEqual(train.command[1:3], ["-m", "accelerate.commands.launch"])
+        self.assertTrue(any("krea2_train_network.py" in str(part) for part in train.command))
+        self.assertEqual(train.command[-2:], ["--config_file", str(train_toml)])
+        self.assertIn("--mixed_precision", train.command)
+        self.assertEqual(train.command[train.command.index("--mixed_precision") + 1], "bf16")
+        self.assertEqual(train.env["ACCELERATE_DISABLE_RICH"], "1")
         self.assertEqual(latents.env["CUDA_VISIBLE_DEVICES"], "0")
         self.assertEqual(latents.env["MUSUBI_PARENT_TASK_ID"], "task-cache_latents")
+
+    def test_train_multi_gpu_uses_accelerate_launch(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            train_toml = root / "t.toml"
+            train_toml.write_text('mixed_precision = "bf16"\n', encoding="utf-8")
+            train = build_train_spec(runtime, train_toml, "task", ["0", "1"])
+
+        self.assertEqual(train.command[0], str(runtime.python))
+        self.assertEqual(train.command[1:3], ["-m", "accelerate.commands.launch"])
+        self.assertIn("--multi_gpu", train.command)
+        self.assertIn("--num_processes", train.command)
+        self.assertEqual(train.command[train.command.index("--num_processes") + 1], "2")
+        self.assertLess(train.command.index("--multi_gpu"), train.command.index("--mixed_precision"))
+        self.assertLess(train.command.index("--mixed_precision"), train.command.index("--config_file"))
+        self.assertEqual(train.env["CUDA_VISIBLE_DEVICES"], "0,1")
+        if sys.platform == "win32":
+            self.assertEqual(train.env["USE_LIBUV"], "0")
+            self.assertIn("--rdzv_backend", train.command)
+            self.assertEqual(train.command[train.command.index("--rdzv_backend") + 1], "c10d")
+
+    def test_cache_uses_first_gpu_only_when_multi_selected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            dataset_toml = root / "d.toml"
+            latents = build_cache_latents_spec(
+                runtime, dataset_toml, "/models/vae.safetensors", "task-cache_latents", ["0", "1"]
+            )
+            te = build_cache_text_encoder_spec(
+                runtime, dataset_toml, "/models/te.safetensors", "task-cache_text_encoder", ["0", "1"]
+            )
+
+        self.assertEqual(latents.env["CUDA_VISIBLE_DEVICES"], "0")
+        self.assertEqual(te.env["CUDA_VISIBLE_DEVICES"], "0")
+        self.assertNotIn("--multi_gpu", latents.command)
+        self.assertNotIn("-m", latents.command)
 
 
 class HelperTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Wrap Musubi/Krea2 train with `python -m accelerate.commands.launch` (upstream-aligned).
- When `gpu_ids` > 1, pass `--multi_gpu --num_processes N` (Windows: `c10d` + `USE_LIBUV=0`).
- Cache latents / TE stay single-process on the first selected GPU.
- Unit tests cover single/multi-GPU argv and cache pinning. Closes #228.

## Test plan
- [x] `python -m unittest tests.test_musubi_backend -v` (19 passed)
- [ ] Dual-GPU short Krea2 train: two devices busy / multi-process logs
- [ ] Single-GPU path unchanged
- [ ] Cache stages do not start multi-process when multiple GPUs selected