### PR TITLE
docs: 整合包构建与发包指南（协作可打包）

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -48,7 +48,7 @@ releases/v2.9.2-rc.1-0813/Next-Trainer-v2.9.2-rc.1-0813-kohya-musubi.7z
 
 要求：Windows 10/11，NVIDIA GPU（建议 RTX 20+）。
 
-补充说明：[整合包补充说明](docs/portable-getting-started.md) · [打标模型目录](docs/tagger-models.md)
+补充说明：[整合包补充说明](docs/portable-getting-started.md) · [打标模型目录](docs/tagger-models.md) · [构建与发包（协作）](docs/portable-build-guide.md)
 
 ### B. 从源码运行 `dev`（Vue3）
 
@@ -174,6 +174,7 @@ Anima Fast：[docs/anima-fast.md](docs/anima-fast.md) · Krea 2 多卡（Linux�
 | **开源引用（子页）** | [docs/credits.md](docs/credits.md) |
 | 法律向完整 NOTICE | [NOTICE.md](NOTICE.md) |
 | 整合包补充 | [docs/portable-getting-started.md](docs/portable-getting-started.md) |
+| **整合包构建与发包（协作）** | [docs/portable-build-guide.md](docs/portable-build-guide.md) |
 | 打标模型 | [docs/tagger-models.md](docs/tagger-models.md) |
 | Anima Fast | [docs/anima-fast.md](docs/anima-fast.md) |
 | **Krea 2 多卡（Linux 部署 + WebUI / `dev`）** | [docs/krea2-linux-multigpu.md](docs/krea2-linux-multigpu.md) |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Legacy UI packages: [Releases](https://github.com/wochenlong/lora-scripts-next/r
 
 Requirements: Windows 10/11, NVIDIA GPU (RTX 20+ recommended).
 
-More: [Portable getting started](docs/portable-getting-started.md) · [Tagger models](docs/tagger-models.md)
+More: [Portable getting started](docs/portable-getting-started.md) · [Tagger models](docs/tagger-models.md) · [Build & release (collaborators)](docs/portable-build-guide.md)
 
 ### B. Run `dev` from source (Vue 3)
 
@@ -169,6 +169,7 @@ See [docs/anima-training.md](docs/anima-training.md) for VRAM tips.
 | **Credits (subpage)** | [docs/credits.md](docs/credits.md) |
 | Full legal NOTICE | [NOTICE.md](NOTICE.md) |
 | Portable notes | [docs/portable-getting-started.md](docs/portable-getting-started.md) |
+| **Portable build & release (collaborators)** | [docs/portable-build-guide.md](docs/portable-build-guide.md) |
 | Tagger models | [docs/tagger-models.md](docs/tagger-models.md) |
 | Anima Fast | [docs/anima-fast.md](docs/anima-fast.md) |
 | **Krea 2 multi-GPU (Linux host + WebUI / `dev`)** | [docs/krea2-linux-multigpu.md](docs/krea2-linux-multigpu.md) |

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -1,20 +1,23 @@
 # build-scripts
 
-Windows 便携整合包构建脚本。详细契约见 [`docs/portable-packaging-git-update.md`](../docs/portable-packaging-git-update.md)。
+Windows 便携整合包构建脚本。
+
+**协作者发包请先读：** [`docs/portable-build-guide.md`](../docs/portable-build-guide.md)（需求、包型、命令、验收、上传权限）。
+
+契约细节：[`docs/portable-packaging-git-update.md`](../docs/portable-packaging-git-update.md)。  
+2026 根目录规格：[`docs/design/portable-2026.md`](../docs/design/portable-2026.md)。
 
 ## 入口
 
-| 脚本 | 用途 |
-|------|------|
-| `build_portable.ps1` | 主流程：Python embed + 复制包内 `SD-Trainer/` + 打 `Next-Trainer-v*.7z` |
-| `build-all.ps1` | 旧版一键构建（`build/sd-trainer-portable`） |
+| 脚本 | 用途 | 典型产出 |
+|------|------|----------|
+| `build_portable.ps1` | **lite**：骨架 + 打标；无预装 Torch | `SD-Trainer-v{VER}.7z` |
+| `build_portable_2026_full.ps1` | **kohya-musubi** 满配（cu128） | `Next-Trainer-v{VER}-kohya-musubi.7z` |
+| `build_portable_kohya_only.ps1` | **kohya** 分轨（`-SkipMusubi`） | `Next-Trainer-v{VER}-kohya.7z` |
+| `build_portable_musubi_only.ps1` | **musubi** 分轨（Krea2） | `Next-Trainer-v{VER}-musubi.7z` |
+| `apply_portable_2026_root.ps1` | 根目录改为 `启动.bat` / `检查更新.bat` / `说明.txt` | （被 full/分轨调用） |
+| `build-all.ps1` | 旧版一键（遗留） | `build/sd-trainer-portable` |
 
-## Anima Fast / 双包（lite · full）
+## Anima Fast（v2.7.0+）
 
-| 参数 | 说明 |
-|------|------|
-| （默认） | **lite**：不预装 Fast；压缩包目标 &lt; 2 GB，适合 GitHub |
-| `-BundleAnimaFast` | **full**：打入已就绪的 `extensions/anima_lora`（含 `.venv`），适合百度网盘 |
-| `-AnimaFastSource` | full 包 Fast 源目录（需含 `.venv\Scripts\python.exe`） |
-
-两包均会预取默认 WD 打标模型到 `tagger-models/wd14/`。详见 [`docs/portable-packaging-git-update.md`](../docs/portable-packaging-git-update.md)。
+**整合包不预装** `extensions/anima_lora/.venv`。`build_portable.ps1` 与 `03-copy-project.ps1` 在 robocopy 时排除整个 `extensions/`。用户在 WebUI **设置 → 训练引擎** 或 Anima Fast 页内安装。

--- a/build-scripts/build_portable_kohya_only.ps1
+++ b/build-scripts/build_portable_kohya_only.ps1
@@ -1,0 +1,85 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Build Kohya-only portable (cu128 main runtime, NO Musubi).
+
+.DESCRIPTION
+  Thin wrapper around build_portable_2026_full.ps1 -SkipMusubi,
+  then rename archive to Next-Trainer-v{Version}-kohya.7z.
+  See docs/portable-build-guide.md.
+#>
+param(
+    [string]$ProjectRoot = (Split-Path $PSScriptRoot -Parent),
+    [Parameter(Mandatory = $false)][string]$Version = "",
+    [string]$TaggerCacheSource = "",
+    [switch]$SkipTaggerPrefetch,
+    [switch]$Skip7z,
+    [switch]$Clean
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $Version) {
+    $versionFile = Join-Path $ProjectRoot "VERSION"
+    if (-not (Test-Path $versionFile)) { throw "VERSION file missing; pass -Version" }
+    $Version = (Get-Content $versionFile -Raw).Trim()
+}
+
+$full = Join-Path $PSScriptRoot "build_portable_2026_full.ps1"
+if (-not (Test-Path $full)) { throw "missing $full" }
+
+$argsHash = @{
+    ProjectRoot = $ProjectRoot
+    Version     = $Version
+    SkipMusubi  = $true
+}
+if ($Clean) { $argsHash.Clean = $true }
+if ($Skip7z) { $argsHash.Skip7z = $true }
+if ($SkipTaggerPrefetch) { $argsHash.SkipTaggerPrefetch = $true }
+if ($TaggerCacheSource) { $argsHash.TaggerCacheSource = $TaggerCacheSource }
+
+Write-Host "Kohya-only portable build v$Version" -ForegroundColor Cyan
+& $full @argsHash
+if ($LASTEXITCODE -ne 0 -and $null -ne $LASTEXITCODE) {
+    throw "build_portable_2026_full.ps1 failed: $LASTEXITCODE"
+}
+
+$buildDir = Join-Path $ProjectRoot "build"
+$portableDir = Join-Path $buildDir "SD-Trainer-Portable"
+$sdtDir = Join-Path $portableDir "SD-Trainer"
+$builtMusubiName = Join-Path $buildDir "Next-Trainer-v${Version}-kohya-musubi.7z"
+$kohyaName = Join-Path $buildDir "Next-Trainer-v${Version}-kohya.7z"
+
+if (-not $Skip7z) {
+    if (Test-Path $builtMusubiName) {
+        if (Test-Path $kohyaName) { Remove-Item $kohyaName -Force }
+        Move-Item $builtMusubiName $kohyaName -Force
+        Write-Host "Archive: $kohyaName" -ForegroundColor Green
+    } elseif (-not (Test-Path $kohyaName)) {
+        Write-Host "WARN: expected archive not found (Skip7z or 7z missing?)" -ForegroundColor Yellow
+    }
+}
+
+if (Test-Path (Join-Path $sdtDir "PORTABLE_BUILD")) {
+    $sha = (& git -C $sdtDir rev-parse HEAD).Trim()
+    $meta = @(
+        $sha,
+        "built_at=$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))",
+        "version=$Version",
+        "flavor=kohya-only"
+    ) -join "`n"
+    [System.IO.File]::WriteAllText((Join-Path $sdtDir "PORTABLE_BUILD"), $meta + "`n")
+}
+
+$note = Join-Path $portableDir "说明.txt"
+if (Test-Path $note) {
+    Add-Content -Path $note -Encoding UTF8 -Value @"
+
+【本包说明 · Kohya-only】
+- 已预装 Kohya 主环境（cu128），可训 Anima / SD / SDXL / Flux 等主线。
+- 未预装 Musubi；Krea2 请用 musubi 或 kohya-musubi 包，或在设置页安装 Musubi。
+- 未预装 Anima Fast；需要时在设置 → 训练引擎安装。
+"@
+}
+
+Write-Host "DONE kohya-only v$Version" -ForegroundColor Green

--- a/build-scripts/build_portable_musubi_only.ps1
+++ b/build-scripts/build_portable_musubi_only.ps1
@@ -1,0 +1,167 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Build Musubi / Krea2-only portable (NO full Kohya torch bake).
+
+.DESCRIPTION
+  1) lite skeleton via build_portable.ps1
+  2) minimal WebUI deps in python_embeded (no training torch index)
+  3) install Musubi engine (cu128)
+  4) 2026 root UX + 7z
+  See docs/portable-build-guide.md.
+#>
+param(
+    [string]$ProjectRoot = (Split-Path $PSScriptRoot -Parent),
+    [Parameter(Mandatory = $false)][string]$Version = "",
+    [string]$TaggerCacheSource = "",
+    [switch]$SkipTaggerPrefetch,
+    [switch]$Skip7z,
+    [switch]$SkipSkeleton,
+    [switch]$Clean
+)
+
+$ErrorActionPreference = "Stop"
+$start = Get-Date
+
+if (-not $Version) {
+    $versionFile = Join-Path $ProjectRoot "VERSION"
+    if (-not (Test-Path $versionFile)) { throw "VERSION file missing; pass -Version" }
+    $Version = (Get-Content $versionFile -Raw).Trim()
+}
+
+$buildDir = Join-Path $ProjectRoot "build"
+$portableDir = Join-Path $buildDir "SD-Trainer-Portable"
+$pythonExe = Join-Path $portableDir "python_embeded\python.exe"
+$sdtDir = Join-Path $portableDir "SD-Trainer"
+$logDir = Join-Path $buildDir "portable-2026-logs"
+New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+$logFile = Join-Path $logDir ("musubi-only-{0:yyyyMMdd-HHmmss}.log" -f (Get-Date))
+
+function Write-Log([string]$Message, [string]$Color = "Gray") {
+    $line = "[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $Message
+    Write-Host $line -ForegroundColor $Color
+    Add-Content -Path $logFile -Value $line -Encoding UTF8
+}
+
+Write-Log "Musubi-only portable build v$Version" "Cyan"
+Write-Log "Log: $logFile" "Cyan"
+
+if ($SkipSkeleton) {
+    Write-Log "[1/4] SkipSkeleton — reuse $portableDir" "Yellow"
+    if (-not (Test-Path $pythonExe)) { throw "missing $pythonExe" }
+} else {
+    Write-Log "[1/4] build_portable.ps1 skeleton (-Skip7z)..." "Cyan"
+    $bp = Join-Path $PSScriptRoot "build_portable.ps1"
+    $bpArgs = @{
+        ProjectRoot = $ProjectRoot
+        Version     = $Version
+        Skip7z      = $true
+    }
+    if ($Clean) { $bpArgs.Clean = $true }
+    if ($SkipTaggerPrefetch) { $bpArgs.SkipTaggerPrefetch = $true }
+    if ($TaggerCacheSource) { $bpArgs.TaggerCacheSource = $TaggerCacheSource }
+    & $bp @bpArgs
+    if ($LASTEXITCODE -ne 0 -and $null -ne $LASTEXITCODE) {
+        throw "build_portable.ps1 failed: $LASTEXITCODE"
+    }
+    if (-not (Test-Path $pythonExe)) { throw "missing $pythonExe" }
+}
+
+Write-Log "[2/4] Minimal WebUI deps (no torch index)..." "Cyan"
+$guiPkgs = @(
+    "fastapi==0.95.1", "uvicorn==0.22.0", "httpx==0.24.1", "toml==0.10.2",
+    "pydantic==1.10.13", "python-multipart", "aiofiles", "jinja2",
+    "rich==13.7.0", "requests", "pillow", "numpy==1.26.4", "safetensors==0.4.4",
+    "huggingface-hub==0.36.2", "modelscope>=1.20.0", "onnxruntime-gpu",
+    "voluptuous==0.13.1", "easygui==0.98.3", "imagesize==1.4.1",
+    "psutil"
+)
+$env:PYTHONUTF8 = "1"
+$prevEap = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
+& $pythonExe -s -m pip install --upgrade pip 2>&1 | ForEach-Object { Add-Content $logFile $_ -Encoding UTF8; $_ }
+$pip1 = $LASTEXITCODE
+& $pythonExe -s -m pip install @guiPkgs 2>&1 | ForEach-Object { Add-Content $logFile $_ -Encoding UTF8; $_ }
+$pip2 = $LASTEXITCODE
+$ErrorActionPreference = $prevEap
+if ($pip1 -ne 0 -or $pip2 -ne 0) { throw "minimal GUI pip failed: pip=$pip1 pkgs=$pip2" }
+
+Write-Log "[3/4] Install Musubi (cu128)..." "Cyan"
+$installMusubi = Join-Path $sdtDir "scripts\cli\install_musubi.py"
+$musubiVendor = Join-Path $sdtDir "vendor\musubi-tuner"
+$musubiMarker = Join-Path $musubiVendor "pyproject.toml"
+if (-not (Test-Path $musubiMarker)) {
+    New-Item -ItemType Directory -Path (Split-Path $musubiVendor -Parent) -Force | Out-Null
+    if (Test-Path $musubiVendor) { Remove-Item $musubiVendor -Recurse -Force }
+    $prev = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+    & git clone --depth=1 https://github.com/kohya-ss/musubi-tuner.git $musubiVendor 2>&1 | ForEach-Object {
+        Write-Host $_; Add-Content $logFile $_ -Encoding UTF8
+    }
+    $ErrorActionPreference = $prev
+    if (-not (Test-Path $musubiMarker)) { throw "musubi-tuner clone failed" }
+}
+$prev = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+& $pythonExe -s $installMusubi --project-root $sdtDir --source-root $musubiVendor --cuda-extra cu128 2>&1 | ForEach-Object {
+    Write-Host $_; Add-Content $logFile $_ -Encoding UTF8
+}
+$code = $LASTEXITCODE
+$ErrorActionPreference = $prev
+if ($code -ne 0) { throw "install_musubi.py failed: $code" }
+
+$musubiPy = Join-Path $sdtDir "extensions\musubi_tuner\.venv\Scripts\python.exe"
+if (-not (Test-Path $musubiPy)) { throw "musubi venv python missing: $musubiPy" }
+& $musubiPy -s -c "import torch; import musubi_tuner; print('musubi_torch', torch.__version__)"
+if ($LASTEXITCODE -ne 0) { throw "musubi torch import failed" }
+
+$sha = (& git -C $sdtDir rev-parse HEAD).Trim()
+$meta = @(
+    $sha,
+    "built_at=$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))",
+    "version=$Version",
+    "flavor=musubi-only"
+) -join "`n"
+[System.IO.File]::WriteAllText((Join-Path $sdtDir "PORTABLE_BUILD"), $meta + "`n")
+
+$applyRoot = Join-Path $PSScriptRoot "apply_portable_2026_root.ps1"
+if (Test-Path $applyRoot) {
+    Write-Log "Applying 2026 root..." "Cyan"
+    & $applyRoot -PortableRoot $portableDir
+}
+
+$note = Join-Path $portableDir "说明.txt"
+if (Test-Path $note) {
+    Add-Content -Path $note -Encoding UTF8 -Value @"
+
+【本包说明 · Musubi / Krea2-only】
+- 已预装 Musubi 引擎，用于 Krea2 LoRA（extensions/musubi_tuner）。
+- 未预装完整 Kohya 主环境 Torch；常规 SDXL / Flux / Anima 请用 kohya 或 kohya-musubi 包。
+- 未预装 Anima Fast 与训练底模。
+"@
+}
+
+$archiveName = "Next-Trainer-v${Version}-musubi.7z"
+$archivePath = Join-Path $buildDir $archiveName
+$7zExe = "C:\Program Files\7-Zip\7z.exe"
+if (-not (Test-Path $7zExe)) {
+    $found = Get-Command 7z -ErrorAction SilentlyContinue
+    if ($found) { $7zExe = $found.Source } else { $7zExe = $null }
+}
+
+if (-not $Skip7z) {
+    Write-Log "[4/4] Compressing $archiveName ..." "Cyan"
+    if (-not $7zExe) {
+        Write-Log "7-Zip not found; left at $portableDir" "Yellow"
+    } else {
+        if (Test-Path $archivePath) { Remove-Item $archivePath -Force }
+        & $7zExe a -t7z -mx=9 -m0=LZMA2:d=64m -ms=on -mmt=on $archivePath "$portableDir\*" | ForEach-Object {
+            Add-Content -Path $logFile -Value $_ -Encoding UTF8
+        }
+        if ($LASTEXITCODE -ne 0) { throw "7z failed: $LASTEXITCODE" }
+        $sizeGb = [math]::Round((Get-Item $archivePath).Length / 1GB, 2)
+        Write-Log "Archive: $archivePath ($sizeGb GB)" "Green"
+    }
+} else {
+    Write-Log "[4/4] Skip7z — $portableDir" "Yellow"
+}
+
+Write-Log ("DONE in {0:N1} min" -f ((Get-Date) - $start).TotalMinutes) "Green"

--- a/docs/portable-build-guide.md
+++ b/docs/portable-build-guide.md
@@ -1,0 +1,241 @@
+# 整合包构建与发包指南（给维护者 / 协作者）
+
+> 面向：**你以外的成员也能按本文打出可发布的 Windows 整合包**。  
+> 仓库：[`wochenlong/lora-scripts-next`](https://github.com/wochenlong/lora-scripts-next)  
+> 产品名：**Next Trainer**；归档前缀：`Next-Trainer-v*.7z`（旧名 `SD-Trainer-v*.7z` 仅兼容）。
+
+相关文档：
+
+| 文档 | 用途 |
+|------|------|
+| 本文 | **怎么打、打哪种、验收、上传** |
+| [`portable-packaging-git-update.md`](portable-packaging-git-update.md) | 目录契约、Git/Release 更新、用户数据保护 |
+| [`design/portable-2026.md`](design/portable-2026.md) | 2026 根目录 UX（`启动.bat` 等）产品规格 |
+| [`portable-getting-started.md`](portable-getting-started.md) | 给用户的 lite 上手 |
+| [`portable-1.5-krea2-guide.md`](portable-1.5-krea2-guide.md) | 满配/Krea2 用户说明 |
+| [`repo-layout.md`](repo-layout.md) | 不可改名的契约路径 |
+| [`team/README.md`](team/README.md) | 谁有权发正式 Release |
+
+本地历史笔记（**不在 Git**）：`build/整合包打包规范.md`（若存在）仅作个人备忘，**以本文与仓库内脚本为准**。
+
+---
+
+## 1. 先选包型（需求）
+
+| 包型 | 谁需要 | 预装内容 | 典型体积 | 构建入口 |
+|------|--------|----------|----------|----------|
+| **lite** | 弱网 / 先开 UI / 自己装引擎 | 嵌入 Python + 代码 + WD 打标；**无** Torch 训练环境 | 7z ~0.4 GB | `build-scripts/build_portable.ps1` |
+| **kohya** | 常规 Anima / SDXL / Flux | lite + **Kohya 主环境（cu128）**；无 Musubi | 7z 数 GB | `build-scripts/build_portable_kohya_only.ps1` |
+| **kohya-musubi** | 傻瓜满配 / Krea2+常规 | Kohya + **Musubi**（cu128）；无 Fast | 7z ~4 GB 级 | `build-scripts/build_portable_2026_full.ps1` |
+| **musubi** | 只要 Krea2、省盘 | lite 骨架 + Musubi；**无**完整 Kohya Torch | 小于满配 | `build-scripts/build_portable_musubi_only.ps1` |
+
+**硬性产品约定（所有包型）：**
+
+- **不预装** Anima Fast（`extensions/anima_lora/.venv`）— 用户在设置页安装  
+- **不预装** 训练底模（Anima / Krea2 权重等）  
+- **建议预置** 默认 WD 打标：`tagger-models/wd14/wd14-convnextv2-v2/`  
+- 解压路径避免中文与空格；目标：Windows 10/11 + NVIDIA（建议 RTX 20+）  
+- 30G 云系统盘：**不要**把三引擎硬塞进同一包；用分轨  
+
+**命名：**
+
+```text
+Next-Trainer-v{VERSION}.7z                 # lite（旧脚本可能仍产出 SD-Trainer-v*.7z）
+Next-Trainer-v{VERSION}-kohya.7z
+Next-Trainer-v{VERSION}-kohya-musubi.7z
+Next-Trainer-v{VERSION}-musubi.7z
+```
+
+`VERSION` 必须与仓库根目录 **`VERSION` 文件**及侧栏一致（正式如 `3.0.0`；候选可用 `3.0.0-rc.1` / 带日期后缀，须在 Release 说明写清）。
+
+---
+
+## 2. 构建机需求
+
+| 项 | 要求 |
+|----|------|
+| OS | Windows 10/11 x64 |
+| 磁盘 | lite：≥ 20 GB 空闲；满配/分轨：建议 ≥ **80 GB**（venv + 7z 临时） |
+| 网络 | 能访问 GitHub、PyPI / 国内镜像、PyTorch cu128 索引（满配必连） |
+| Git | 已安装；`origin` = `https://github.com/wochenlong/lora-scripts-next.git` |
+| 7-Zip | `C:\Program Files\7-Zip\7z.exe` 或 PATH 中有 `7z` |
+| Python | **官方 CPython 3.10**（带 `tcl/`），用于给 embed 补 tkinter。优先 `C:\Program Files\Python310\`。**不要用**缺 tcl 的 conda |
+| 权限 | 能在仓库旁写 `build/`；正式上传需 GitHub Release / 魔搭权限（见 §6） |
+| 可选 | 本机已有旧整合包或完整 `tagger-models/`，作 `-TaggerCacheSource` 种子，避免重复下 ONNX |
+
+**不要用「正在开发、脏工作区」直接打进包。** 见 §3。
+
+---
+
+## 3. 代码基线（发包前）
+
+```powershell
+git fetch origin
+# 正式稳定包（切 main 之后）：跟踪 main
+# Vue3 / 3.0.0 候选与当前内测：跟踪 dev
+git switch dev
+git pull origin dev
+git status   # 必须干净
+Get-Content VERSION
+git log -1 --oneline
+```
+
+检查清单：
+
+- [ ] 工作区无未提交改动（或只用干净 worktree）  
+- [ ] `VERSION` 与拟发布号一致  
+- [ ] `frontend/dist` 与源码一致（改过 Vue 须先 `cd frontend && npm ci && npm run build`）  
+- [ ] 未把本机 `data/`、`doc/`、`script/`、模型、密钥打进树  
+- [ ] Fast：确认不会打包进维护机上的 `extensions/anima_lora/`（脚本已排除 `extensions/`）
+
+推荐：单独 worktree 构建，避免踩开发目录。
+
+```powershell
+git worktree add D:\build\lora-scripts-next-portable origin/dev
+cd D:\build\lora-scripts-next-portable
+```
+
+---
+
+## 4. 构建命令
+
+以下均在**仓库根目录**执行。把 `3.0.0` 换成实际版本号。
+
+### 4.1 lite（体积小、首次启动再装依赖）
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\build-scripts\build_portable.ps1 `
+  -Clean -Version 3.0.0 `
+  -TaggerCacheSource D:\path\to\seed-with-tagger-models
+```
+
+| 输出 | 路径 |
+|------|------|
+| 目录 | `build\SD-Trainer-Portable\` |
+| 7z | `build\SD-Trainer-v3.0.0.7z`（当前 lite 脚本仍用此文件名；上传时可改名或说明） |
+
+常用参数：`-Skip7z`、`-SkipTaggerPrefetch`、`-TaggerCacheSource <含 tagger-models 的旧包或仓库>`。
+
+入口：用户双击 **`run_gui.bat`**（首次联网装主环境）。
+
+### 4.2 kohya-musubi（满配）
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\build-scripts\build_portable_2026_full.ps1 `
+  -Clean -Version 3.0.0 `
+  -TaggerCacheSource D:\path\to\seed-with-tagger-models
+```
+
+| 输出 | 路径 |
+|------|------|
+| 目录 | `build\SD-Trainer-Portable\`（根目录为 `启动.bat` / `检查更新.bat` / `说明.txt`） |
+| 7z | `build\Next-Trainer-v3.0.0-kohya-musubi.7z` |
+| 日志 | `build\portable-2026-logs\` |
+
+耗时长（装 Torch ×2），需稳定网络。
+
+### 4.3 kohya-only
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\build-scripts\build_portable_kohya_only.ps1 `
+  -Clean -Version 3.0.0 `
+  -TaggerCacheSource D:\path\to\seed-with-tagger-models
+```
+
+输出：`build\Next-Trainer-v3.0.0-kohya.7z`。
+
+### 4.4 musubi-only（Krea2 分轨）
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\build-scripts\build_portable_musubi_only.ps1 `
+  -Clean -Version 3.0.0 `
+  -TaggerCacheSource D:\path\to\seed-with-tagger-models
+```
+
+输出：`build\Next-Trainer-v3.0.0-musubi.7z`。  
+本包主环境不烤满 Kohya Torch；常规 SDXL/Flux/Anima 请用 kohya 包。
+
+---
+
+## 5. 构建后验收（上传前必做）
+
+### 5.1 自动
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\portable\verify_portable_release.ps1 `
+  -PortableRoot .\build\SD-Trainer-Portable `
+  -ArchivePath .\build\Next-Trainer-v3.0.0-kohya-musubi.7z `
+  -ExpectedVersion 3.0.0
+
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\portable\verify_portable_updaters.ps1
+```
+
+（lite 的 `-ArchivePath` 换成实际 7z 名；`-ExpectedVersion` 与 `VERSION` 一致。）
+
+### 5.2 手工冒烟（至少）
+
+1. 解压到**干净路径**（非构建目录亦可）。  
+2. 双击入口：lite → `run_gui.bat`；2026 根 → `启动.bat`。  
+3. 打开 `http://127.0.0.1:28000`，侧栏 / `/api/version` = 预期版本。  
+4. 设置 → 引擎状态可读；满配包 Musubi 应为就绪或可修复。  
+5. **P0**：能提交一次训练或至少 `POST /api/run` 不因缺 `config/autosave` 等 500（见打包规范历史教训）。  
+6. 确认包内**无**维护机 `extensions/anima_lora/.venv`、无训练底模、无个人数据。
+
+把 commit、`PORTABLE_BUILD` 内容、7z 大小/SHA256 记在 Release 说明或内部验收帖。
+
+---
+
+## 6. 上传与发布权限
+
+| 渠道 | 谁 | 怎么做 |
+|------|-----|--------|
+| GitHub Release | 默认 **@wochenlong**；获授权维护者可用 `gh release` | tag 如 `v3.0.0`；资产挂 7z；正文写包型与体积 |
+| 魔搭数据集 | 需有 `windsing/next-trainer-portable`（或指定仓库）写权限 | 路径建议 `releases/v{VERSION}/Next-Trainer-v{VERSION}-*.7z` |
+
+**未获 Release 权限的成员**：把验收过的 7z + SHA256 + 构建 commit 交给有权限者上传，或开 Discussion/Issue 交接。
+
+`gh` 示例（有权限时）：
+
+```powershell
+gh release create v3.0.0 `
+  -R wochenlong/lora-scripts-next `
+  --title "Next Trainer v3.0.0" `
+  --notes-file release-notes.md `
+  .\build\Next-Trainer-v3.0.0-lite.7z `
+  .\build\Next-Trainer-v3.0.0-kohya.7z `
+  .\build\Next-Trainer-v3.0.0-kohya-musubi.7z
+```
+
+（文件名以实际产出为准。）
+
+---
+
+## 7. 禁止事项
+
+- 改名/移动契约：`python_embeded/`、`SD-Trainer/`、`gui.py`、`run_gui.bat` 等（见 [`repo-layout.md`](repo-layout.md)）  
+- 把完整 `.git` 历史打进包（应用浅克隆元数据；体积异常大要返工）  
+- 用脏工作区、本机模型、Token、`doc/local` 私货进包  
+- 预装 Fast venv「图省事」  
+- 未跑 §5 就上传对外链接  
+
+---
+
+## 8. 故障速查
+
+| 现象 | 处理 |
+|------|------|
+| tkinter / 文件选择器挂 | 构建机换官方 CPython 3.10；或从旧包复制 tcl / `_tkinter` |
+| 打标模型重复下载慢 | `-TaggerCacheSource` 指向已有 `tagger-models` |
+| 满配 pip/Torch 失败 | 换镜像、查 `build/portable-2026-logs/`；可先 lite 再本机装引擎对比 |
+| 7z 过大 | 确认未打入 `data/`、完整 git、Fast venv；满配用 solid 7z（脚本已 `-ms=on`） |
+| 用户「无法连接后端」 | 查包内日志与 `config/autosave`；勿只当端口问题 |
+
+---
+
+## 9. 3.0.0 阶段建议节奏
+
+1. `dev` 技术验收（Discussion 协作清单）无阻断  
+2. 按本文打 **候选包**（版本号可带 rc/日期）→ **内测群**  
+3. 修阻断后再打正式号 → 切 `main` / 发 Release / 公开发链接  
+
+教程与首页视觉**不阻塞**打包技术验收，但正式对外说明里建议链到用户文档。

--- a/docs/portable-packaging-git-update.md
+++ b/docs/portable-packaging-git-update.md
@@ -2,6 +2,8 @@
 
 本文记录 Windows 便携整合包的打包契约，以及将整合包改为"保留 `.git`、支持一键 Git 更新"后的实现方案。
 
+> **要自己打 7z / 分轨包？** 请先看协作指南：[**portable-build-guide.md**](portable-build-guide.md)（环境需求、包型、命令、验收、上传权限）。
+
 > **团队约定与变迁记录**：[Discussion #73 — 整合包更新机制](https://github.com/wochenlong/lora-scripts-next/discussions/73)（双通道、bootstrap、`UPDATER_VERSION` 演进索引）
 
 > **v2.5.2 用户**：若出现「能开网页但无法开始训练」，请升级到 **v2.5.3**（见 [`portable-upgrade-2.5.2-to-2.5.3.md`](portable-upgrade-2.5.2-to-2.5.3.md)，[Issue #54](https://github.com/wochenlong/lora-scripts-next/issues/54)）。

--- a/docs/team/README.md
+++ b/docs/team/README.md
@@ -62,7 +62,8 @@
 | **PR Review** | 当前阶段 @wochenlong |
 | **`main`** | 可发布基线；**不直接在 `main` 开发**，功能分支 + PR |
 
-整合包见 [`build/整合包打包规范.md`](../../build/整合包打包规范.md)。
+整合包构建与发包（公开、可协作）：[`docs/portable-build-guide.md`](../portable-build-guide.md)。  
+目录契约与更新机制：[`docs/portable-packaging-git-update.md`](../portable-packaging-git-update.md)。
 
 ---
 


### PR DESCRIPTION
## Summary
- Add public `docs/portable-build-guide.md`: requirements, lite/kohya/musubi/full flavors, commands, verification, upload permissions
- Add `build_portable_kohya_only.ps1` / `build_portable_musubi_only.ps1` (no hardcoded machine paths)
- Point `build-scripts/README.md`, `docs/team/README.md`, and packaging notes at the new guide

## Test plan
- [ ] Open `docs/portable-build-guide.md` and confirm package matrix matches current product
- [ ] Dry-read PowerShell wrappers for path defaults (`ProjectRoot` from script location)
- [ ] Optional: run lite `-Skip7z` on a clean worktree if a builder is available