### PR TITLE
docs: main 转正说明 + README 焕新排版

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,169 +1,211 @@
 ﻿# Next Trainer
 
-**Next Trainer** 是 Windows 本地训练 WebUI（GitHub 仓库名：`lora-scripts-next`）。  
-支持 Anima / SD 1.5 / SDXL / Flux / **Krea 2** 的 LoRA 与全量微调；基于 [kohya-ss/sd-scripts](https://github.com/kohya-ss/sd-scripts)，可选 [musubi-tuner](https://github.com/kohya-ss/musubi-tuner)，延续秋叶系训练体验。
+<p align="center">
+  <img src="assets/readme/next-trainer-cover.png" alt="Next Trainer" width="720" />
+</p>
 
-> 产品品牌与发布归档一律为 **Next Trainer** / `Next-Trainer-v*.7z`。整合包内目录名 `SD-Trainer/`（及 `Update-SD-Trainer*.bat`）仍为兼容旧安装的启动契约，暂不改名。
+<p align="center">
+  <strong>本地 Windows 训练 WebUI</strong><br />
+  Anima · SD 1.5 · SDXL · Flux · Krea 2<br />
+  <sub>GitHub 仓库名：<code>lora-scripts-next</code></sub>
+</p>
 
-[English](README.md) · [开源引用](docs/credits.md) · [NOTICE](NOTICE.md) · [CHANGELOG](CHANGELOG.md)
+<p align="center">
+  <a href="README.md">English</a>
+  ·
+  <a href="docs/credits.md">开源引用</a>
+  ·
+  <a href="CHANGELOG.md">更新日志</a>
+  ·
+  <a href="https://github.com/wochenlong/lora-scripts-next/releases">Releases</a>
+</p>
 
 ---
 
-## 分支与版本（请先读）
+## `main` 已切换（请先读）
 
-| 分支 | 用途 | 界面 | 版本号 |
-|------|------|------|--------|
-| **`main`** | 稳定发布（切换前仍为旧 UI） | 旧版前端（预编译 dist） | **v2.9.1**（即将迁入 `legacy`） |
-| **`dev`** | **Vue3 正式线（本 README）** | Vue 3 四栏工作台 | **`3.0.0`** |
+**默认分支 `main` 已从旧版多页 UI（v2.9.1）切换为 Vue 3 工作台（`3.0.0`）。**
 
-**版本约定：** 预发布曾使用 **`2.9.x`**（`beta` → `rc`）；**本线正式号为 `3.0.0`**。默认分支切换与正式整合包发布后，请以侧栏版本与 Release 归档名为准。反馈 Issue 时请附上完整版本号。
+| | |
+|---|---|
+| **改了什么** | 默认检出 / 跟踪 `main` 时，得到的是 **Vue 3 四栏工作台**（训练 · 数据集 · 任务 · 设置），产品正式号为 **`3.0.0`**。旧版侧栏多 HTML 前端不再是 `main` 的默认内容。 |
+| **为什么改** | Vue 3 线在 `dev` 上完成内测与关键门禁后，需要成为**默认稳定基线**：统一品牌（Next Trainer）、统一 IA、降低「默认分支还是旧 UI」的混淆，并让后续修复与正式整合包都落在同一条线上。 |
+| **没改什么** | 整合包内目录名 `SD-Trainer/`、更新脚本文件名等**启动契约**暂时保留，兼容已有安装。训练引擎（Kohya / Anima Fast / Musubi）仍为可选项，按包体与设置页安装。 |
+
+> **合 `main` ≠ 立刻推正式 3.0.0 整合包。** 源码默认线已是 3.0.0；正式 7z / 「点更新」仍以 GitHub Release 为准，建议先浸泡再全量推送。
+
+### 需要旧版 `main`（v2.9.1 UI）？
+
+旧稳定线已完整备份，可随时回退对照：
+
+| 资源 | 链接 |
+|------|------|
+| **分支 `legacy/v2.9.1`** | [github.com/…/tree/legacy/v2.9.1](https://github.com/wochenlong/lora-scripts-next/tree/legacy/v2.9.1) |
+| **标签 `legacy-v2.9.1-pre-vue3`** | [github.com/…/releases/tag/legacy-v2.9.1-pre-vue3](https://github.com/wochenlong/lora-scripts-next/releases/tag/legacy-v2.9.1-pre-vue3)（与转正前 `main` tip 同一提交） |
+| **旧 UI 整合包** | [Releases → v2.9.1](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.1) |
+
+源码检出旧线：
+
+```powershell
+git fetch origin
+git switch legacy/v2.9.1
+# 或固定到标签：
+# git switch --detach legacy-v2.9.1-pre-vue3
+```
 
 ---
 
-## 下载 Next Trainer 整合包
+## 这是什么
 
-| 包 | 内容 | 下载 |
+**Next Trainer** 面向本地 Windows（NVIDIA）的 LoRA / 全量微调 WebUI。  
+基于 [kohya-ss/sd-scripts](https://github.com/kohya-ss/sd-scripts)，可选 [musubi-tuner](https://github.com/kohya-ss/musubi-tuner)；延续秋叶系训练习惯，产品名与发布归档统一为 **Next Trainer** / `Next-Trainer-v*.7z`。
+
+---
+
+## 分支怎么选
+
+| 分支 | 角色 | 界面 | 版本 |
+|------|------|------|------|
+| **`main`** | **当前默认稳定线** | Vue 3 工作台 | **`3.0.0`** |
+| **`dev`** | 继续试验、预发布功能 | 同为 Vue 3（可能超前 `main`） | 跟随试验 |
+| **`legacy/v2.9.1`** | 旧 UI 备份，不默认开发 | 旧版预编译前端 | **v2.9.1** |
+
+反馈 Issue 时请附上侧栏完整版本号与分支（或整合包 Release 名）。
+
+---
+
+## 下载整合包
+
+| 包 | 说明 | 获取 |
 |----|------|------|
-| **3.0.0 正式包** | 准备中（lite / Kohya / Musubi 分轨） | 即将发布到 GitHub Release `v3.0.0` 与魔搭 |
-| **RC 试用（仍可用）** | lite ~0.39 GB；kohya-musubi ~4.2 GB | [GitHub v2.9.2-rc.1-0813](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.2-rc.1-0813) · [魔搭 windsing/next-trainer-portable](https://modelscope.cn/datasets/windsing/next-trainer-portable) |
+| **3.0.0 正式包** | 准备中（lite / Kohya / Musubi 分轨） | 即将发布到 GitHub `v3.0.0` 与魔搭 |
+| **RC 试用** | lite ~0.39 GB；kohya-musubi ~4.2 GB（Vue 3 预览可用） | [v2.9.2-rc.1-0813](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.2-rc.1-0813) · [魔搭](https://modelscope.cn/datasets/windsing/next-trainer-portable) |
+| **旧 UI 稳定包** | 多页 dist / v2.9.1 | [v2.9.1](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.1) |
 
-RC 魔搭示例路径：
+魔搭 RC 示例路径：
 
 ```text
 releases/v2.9.2-rc.1-0813/Next-Trainer-v2.9.2-rc.1-0813-kohya-musubi.7z
 ```
 
-旧 UI 稳定包仍见 [Releases](https://github.com/wochenlong/lora-scripts-next/releases) 中 **v2.9.1**。
+要求：Windows 10/11，NVIDIA GPU（建议 RTX 20+）；解压路径避免中文与空格。
+
+补充：[整合包说明](docs/portable-getting-started.md) · [打标模型](docs/tagger-models.md) · [构建与发包（协作）](docs/portable-build-guide.md)
 
 ---
 
-## 怎么用
+## 快速开始
 
-### A. 整合包
+### 整合包
 
-1. **正式 3.0.0 包发布前**：可继续用上表 RC 包试用 Vue3（侧栏可能仍显示 rc；源码 `dev` 已为 `3.0.0`）  
-2. 解压到**非中文、非空格**路径；**lite** 用 `run_gui.bat`，满配/分轨包按包内说明（如 `启动.bat`）  
-3. 打开 **http://127.0.0.1:28000**  
-4. 正式包侧栏应显示 **`v3.0.0`**
+1. 解压后运行 `run_gui.bat`（或包内写明的启动脚本）  
+2. 浏览器打开 **http://127.0.0.1:28000**  
+3. 正式 3.0.0 包侧栏应显示 **`v3.0.0`**（RC 包可能仍带 rc 徽标）
 
-要求：Windows 10/11，NVIDIA GPU（建议 RTX 20+）。
-
-补充说明：[整合包补充说明](docs/portable-getting-started.md) · [打标模型目录](docs/tagger-models.md) · [构建与发包（协作）](docs/portable-build-guide.md)
-
-### B. 从源码运行 `dev`（Vue3）
+### 从源码跑当前 `main`（Vue 3）
 
 ```powershell
 git clone https://github.com/wochenlong/lora-scripts-next.git
 cd lora-scripts-next
+git checkout main
+git pull
 
-# 切换到 Vue3 正式线（dev）
-git fetch origin
-git checkout dev
-git pull origin dev
-
-# Windows：准备环境后启动（需本机 Python 3.10）
 .\run_gui.bat
 # 或：python gui.py --dev
 ```
 
-查看当前分支与版本：
-
 ```powershell
-git branch --show-current   # 应为 dev
-Get-Content VERSION         # 应为 3.0.0
+git branch --show-current   # main
+Get-Content VERSION         # 3.0.0
 ```
 
-前端源码在 `frontend/`（Vue 3 + Vite）。日常开发：
+前端工程在 `frontend/`（Vue 3 + Vite）：
 
 ```powershell
 cd frontend
 npm install
-npm run dev          # 热更新（需后端 gui 已启动）
-npm run build        # 产物写入 frontend/dist，供 gui 静态托管
+npm run dev      # 热更新（需后端已启动）
+npm run build    # 写入 frontend/dist
 ```
 
-### C. 从 `main` 切到 `dev`（已有克隆）
+### 跟着试验线 `dev`
 
 ```powershell
 git fetch origin
 git switch dev
-# 若本地已有旧分支名，也可：git checkout -B dev origin/dev
 git pull
 ```
 
-回到稳定线：
-
-```powershell
-git switch main
-git pull
-```
-
-> **注意：** `main` 与 `dev` 前端架构不同，不要混用未提交的 `frontend/dist` 热修。整合包用户以整包版本为准，不必手动切分支。
+> `main` / `dev` / `legacy` 前端架构不同，不要混提未提交的 `frontend/dist` 热修。整合包用户以整包版本为准。
 
 ---
 
-## Vue3 功能（`dev` / 3.0.0）
-
-相对旧版侧栏多页 dist，**`dev` 为 Vue 3 单页工作台**：
+## 功能一览
 
 | 模块 | 能力 |
 |------|------|
-| **训练** | 基础模型 × 训练引擎 × 训练目标；右侧 TOML 预览；校验 / 导入导出 / 开始训练 |
-| **数据集** | 模型打标（内置 WD14）+ **以图为主的标签编辑**（顶栏数据源/加载；筛选与批量编辑在右侧面板） |
-| **任务** | 任务列表、状态、日志、预览 / Loss；日常盯盘以任务页为主 |
-| **设置** | UI 偏好（含浅色/深色主题）、**训练引擎管理**（Kohya / Anima Fast / Musubi）、**下载源**（pip / PyTorch / HF / GitHub 镜像）、关于、更新日志 |
-| **品牌与版本** | 产品名统一为 **Next Trainer**；正式号 **`3.0.0`**（预发布号仍会显示 RC 徽标） |
-| **开源致谢** | 设置 → 关于；仓库另有 [开源引用](docs/credits.md) 子页 |
+| **训练** | 基础模型 × 引擎 × 目标；右侧 TOML 预览；校验 / 导入导出 / 开训 |
+| **数据集** | WD14 打标；以图为主的标签编辑（筛选与批量在右侧） |
+| **任务** | 列表、状态、日志、预览 / Loss；日常盯盘入口 |
+| **设置** | 主题与 UI、引擎管理（Kohya / Anima Fast / Musubi）、下载源镜像、关于与更新日志 |
 
-训练能力包括：
+训练后端：Anima LoRA / Fast / 全量、SD·SDXL、Flux（Kohya）；可选 **Krea 2**（Musubi）。另有本地打标、`/train-monitor`、TensorBoard。
 
-- Anima LoRA / LoKr / T-LoRA、Anima Fast（插件）、Anima 全量微调  
-- SD 1.5 / SDXL LoRA 与全量微调、Flux LoRA  
-- **Krea 2 LoRA**（可选 **Musubi-Tuner** 引擎，设置页安装）  
-- 本地打标、训练监控（`/train-monitor`）、TensorBoard  
-
-Anima Fast：[docs/anima-fast.md](docs/anima-fast.md) · Krea 2 多卡（Linux）：[docs/krea2-linux-multigpu.md](docs/krea2-linux-multigpu.md)
+- Anima Fast → [docs/anima-fast.md](docs/anima-fast.md)  
+- Krea 2 多卡（Linux）→ [docs/krea2-linux-multigpu.md](docs/krea2-linux-multigpu.md)
 
 ### 界面预览
 
-截图来自 `dev` / Vue3（`3.0.0` 线；界面语言为中文）。
+截图来自 Vue 3（`3.0.0` 线，中文界面）。
 
-#### 训练
+<details open>
+<summary><strong>训练</strong></summary>
 
-| 标准（Kohya / Anima LoRA） | Anima Fast | Krea 2（Musubi） |
+| 标准（Kohya / Anima） | Anima Fast | Krea 2（Musubi） |
 |---|---|---|
 | ![训练 · 标准](assets/readme/vue3/01-training-standard.png) | ![训练 · Fast](assets/readme/vue3/02-training-fast.png) | ![训练 · Krea 2](assets/readme/vue3/08-training-krea2.png) |
 
-#### 数据集
+</details>
+
+<details>
+<summary><strong>数据集</strong></summary>
 
 | 模型打标 | 标签编辑 |
 |---|---|
-| ![数据集 · 打标](assets/readme/vue3/03-dataset-tagger.png) | ![数据集 · 标签编辑](assets/readme/vue3/04-dataset-editor.png) |
+| ![打标](assets/readme/vue3/03-dataset-tagger.png) | ![标签编辑](assets/readme/vue3/04-dataset-editor.png) |
 
-#### 任务
+</details>
+
+<details>
+<summary><strong>任务</strong></summary>
 
 ![任务](assets/readme/vue3/05-tasks.png)
 
-#### 设置
+</details>
+
+<details>
+<summary><strong>设置</strong></summary>
 
 | 界面偏好 | 训练引擎 |
 |---|---|
-| ![设置 · 界面](assets/readme/vue3/07-settings-ui.png) | ![设置 · 训练引擎](assets/readme/vue3/06-settings-engines.png) |
+| ![设置 · 界面](assets/readme/vue3/07-settings-ui.png) | ![设置 · 引擎](assets/readme/vue3/06-settings-engines.png) |
+
+</details>
 
 ---
 
-## 支持一览
+## 支持的模式
 
 | 模式 | 说明 |
 |------|------|
 | Anima LoRA | LoRA · LoKr · T-LoRA · 约 12GB 显存起 |
 | Anima Fast | 可选独立运行时 · 建议 16GB+ · 设置页安装 |
-| Anima 全量微调 | 完整 DiT · 建议约 24GB |
+| Anima 全量 | 完整 DiT · 建议约 24GB |
 | SD 1.5 / SDXL | LoRA / 全量微调 |
 | Flux | LoRA |
-| Krea 2 | LoRA（Musubi）· 设置页安装引擎 · Linux 可多卡 |
+| Krea 2 | LoRA（Musubi）· 设置页装引擎 · Linux 可多卡 |
 
-显存与进阶参数见 [docs/anima-training.md](docs/anima-training.md)。
+显存与参数：[docs/anima-training.md](docs/anima-training.md)
 
 ---
 
@@ -171,29 +213,38 @@ Anima Fast：[docs/anima-fast.md](docs/anima-fast.md) · Krea 2 多卡（Linux�
 
 | 主题 | 链接 |
 |------|------|
-| **开源引用（子页）** | [docs/credits.md](docs/credits.md) |
-| 法律向完整 NOTICE | [NOTICE.md](NOTICE.md) |
+| 开源引用 | [docs/credits.md](docs/credits.md) |
+| NOTICE | [NOTICE.md](NOTICE.md) |
 | 整合包补充 | [docs/portable-getting-started.md](docs/portable-getting-started.md) |
-| **整合包构建与发包（协作）** | [docs/portable-build-guide.md](docs/portable-build-guide.md) |
+| 构建与发包 | [docs/portable-build-guide.md](docs/portable-build-guide.md) |
 | 打标模型 | [docs/tagger-models.md](docs/tagger-models.md) |
-| Anima Fast | [docs/anima-fast.md](docs/anima-fast.md) |
-| **Krea 2 多卡（Linux 部署 + WebUI / `dev`）** | [docs/krea2-linux-multigpu.md](docs/krea2-linux-multigpu.md) |
 | 训练监控 | [docs/train-monitor.md](docs/train-monitor.md) |
 | 仓库布局契约 | [docs/repo-layout.md](docs/repo-layout.md) |
 
 ---
 
-## 常见问题（简）
+## 常见问题
 
-**反馈 Bug 要带什么？**  
-完整版本号（侧栏）、训练类型（模型/引擎/目标）、复现步骤、相关日志。→ [Issues](https://github.com/wochenlong/lora-scripts-next/issues)
+**Bug 反馈要带什么？**  
+侧栏完整版本、训练类型（模型/引擎/目标）、复现步骤、相关日志。→ [Issues](https://github.com/wochenlong/lora-scripts-next/issues)
 
 **lite 和 kohya-musubi 怎么选？**  
-弱网 / 轻量入口 → lite（首次启动装依赖）。要开箱 Kohya + Musubi（可训 Krea 2）→ **kohya-musubi**（魔搭）。Anima Fast 两包都需在设置页安装。
+弱网 / 轻量 → lite（首次装依赖）。要开箱 Kohya + Musubi（可训 Krea 2）→ **kohya-musubi**。Anima Fast 均需在设置页安装。
 
 **3.0.0 和旧稳定版能混用配置吗？**  
-多数 TOML 可导入；导航与存储 key 有差异，以当前页「导入配置」为准。
+多数 TOML 可导入；导航与本地存储 key 有差异，以当前页「导入配置」为准。
+
+**更新后界面全变了？**  
+这是预期行为：`main` 已是 Vue 3。若必须使用旧 UI，请切到 [`legacy/v2.9.1`](https://github.com/wochenlong/lora-scripts-next/tree/legacy/v2.9.1) 或安装 [v2.9.1 整合包](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.1)。
 
 ---
 
-<p align="center"><sub>维护：<a href="https://github.com/wochenlong">@wochenlong</a> · <a href="docs/credits.md">开源引用</a> · <a href="CONTRIBUTORS.md">贡献者</a></sub></p>
+<p align="center">
+  <sub>
+    维护 <a href="https://github.com/wochenlong">@wochenlong</a>
+    ·
+    <a href="docs/credits.md">开源引用</a>
+    ·
+    <a href="CONTRIBUTORS.md">贡献者</a>
+  </sub>
+</p>

--- a/README.md
+++ b/README.md
@@ -1,73 +1,122 @@
 ﻿# Next Trainer
 
-**Next Trainer** is a local Windows training WebUI (GitHub repo: `lora-scripts-next`).  
-LoRA and full finetune for Anima / SD 1.5 / SDXL / Flux / Krea 2, built on [kohya-ss/sd-scripts](https://github.com/kohya-ss/sd-scripts) (and optional [musubi-tuner](https://github.com/kohya-ss/musubi-tuner)) with an Akegarasu-style workflow.
+<p align="center">
+  <img src="assets/readme/next-trainer-cover.png" alt="Next Trainer" width="720" />
+</p>
 
-> Product brand and release archives use **Next Trainer** / `Next-Trainer-v*.7z`. The portable layout folder `SD-Trainer/` (and updater bat names) stay as launcher contracts for existing installs.
+<p align="center">
+  <strong>Local Windows training WebUI</strong><br />
+  Anima · SD 1.5 · SDXL · Flux · Krea 2<br />
+  <sub>GitHub repository: <code>lora-scripts-next</code></sub>
+</p>
 
-[中文](README-zh.md) · [Credits](docs/credits.md) · [NOTICE](NOTICE.md) · [CHANGELOG](CHANGELOG.md)
+<p align="center">
+  <a href="README-zh.md">中文</a>
+  ·
+  <a href="docs/credits.md">Credits</a>
+  ·
+  <a href="CHANGELOG.md">Changelog</a>
+  ·
+  <a href="https://github.com/wochenlong/lora-scripts-next/releases">Releases</a>
+</p>
 
 ---
 
-## Branches and versions
+## `main` has changed (read this first)
+
+**The default branch `main` is no longer the legacy multi-page UI (v2.9.1). It is now the Vue 3 workspace (`3.0.0`).**
+
+| | |
+|---|---|
+| **What changed** | Cloning or tracking `main` now gives you the **Vue 3 four-pane workspace** (Training · Dataset · Tasks · Settings) at product version **`3.0.0`**. The old sidebar multi-HTML frontend is no longer what `main` ships. |
+| **Why** | After soak and gate fixes on `dev`, Vue 3 needs to be the **default stable baseline**: one brand (Next Trainer), one IA, less “default branch is still the old UI” confusion, and one line for fixes plus formal portable builds. |
+| **What did not change** | Portable layout folder `SD-Trainer/` and updater bat **names** stay as launcher contracts for existing installs. Engines (Kohya / Anima Fast / Musubi) remain optional by package and Settings install. |
+
+> **Merging to `main` ≠ shipping a formal 3.0.0 portable the same day.** Source default is already `3.0.0`; user-facing 7z / “check for updates” still follow GitHub Releases after soak.
+
+### Need the old `main` (v2.9.1 UI)?
+
+The previous stable line is fully preserved:
+
+| Resource | Link |
+|----------|------|
+| **Branch `legacy/v2.9.1`** | [github.com/…/tree/legacy/v2.9.1](https://github.com/wochenlong/lora-scripts-next/tree/legacy/v2.9.1) |
+| **Tag `legacy-v2.9.1-pre-vue3`** | [github.com/…/releases/tag/legacy-v2.9.1-pre-vue3](https://github.com/wochenlong/lora-scripts-next/releases/tag/legacy-v2.9.1-pre-vue3) (same tip as pre-cutover `main`) |
+| **Legacy UI portable** | [Releases → v2.9.1](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.1) |
+
+Check out the old line:
+
+```sh
+git fetch origin
+git switch legacy/v2.9.1
+# or pin the tag:
+# git switch --detach legacy-v2.9.1-pre-vue3
+```
+
+---
+
+## What it is
+
+**Next Trainer** is a local Windows (NVIDIA) WebUI for LoRA and full finetune.  
+Built on [kohya-ss/sd-scripts](https://github.com/kohya-ss/sd-scripts), with optional [musubi-tuner](https://github.com/kohya-ss/musubi-tuner), in an Akegarasu-style workflow. Product brand and release archives use **Next Trainer** / `Next-Trainer-v*.7z`.
+
+---
+
+## Branches
 
 | Branch | Role | UI | Version |
 |--------|------|----|---------|
-| **`main`** | Stable (legacy UI until cutover) | Legacy prebuilt frontend | **v2.9.1** (moving to `legacy`) |
-| **`dev`** | **Vue 3 formal line** (this README) | Vue 3 four-pane workspace | **`3.0.0`** |
+| **`main`** | **Current default stable** | Vue 3 workspace | **`3.0.0`** |
+| **`dev`** | Ongoing experiments / previews | Vue 3 (may lead `main`) | experimental |
+| **`legacy/v2.9.1`** | Old UI backup (not default) | Legacy prebuilt frontend | **v2.9.1** |
 
-**Versioning:** pre-releases used **`2.9.x`** (`beta` → `rc`); **formal Vue 3 release is `3.0.0`**. After default-branch cutover and portable GA, trust the sidebar version and Release archive names. Include the full version when filing issues.
+When filing issues, include the full sidebar version and branch (or Release archive name).
 
 ---
 
-## Portable packages (Next Trainer)
+## Portable downloads
 
-| Package | Contents | Download |
-|---------|----------|----------|
-| **3.0.0 GA** | Preparing (lite / Kohya / Musubi flavors) | Coming to GitHub Release `v3.0.0` and ModelScope |
-| **RC (still usable)** | lite ~0.39 GB; kohya-musubi ~4.2 GB | [GitHub v2.9.2-rc.1-0813](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.2-rc.1-0813) · [ModelScope windsing/next-trainer-portable](https://modelscope.cn/datasets/windsing/next-trainer-portable) |
+| Package | Notes | Get it |
+|---------|-------|--------|
+| **3.0.0 GA** | Preparing (lite / Kohya / Musubi flavors) | Coming to GitHub `v3.0.0` and ModelScope |
+| **RC preview** | lite ~0.39 GB; kohya-musubi ~4.2 GB (Vue 3 usable) | [v2.9.2-rc.1-0813](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.2-rc.1-0813) · [ModelScope](https://modelscope.cn/datasets/windsing/next-trainer-portable) |
+| **Legacy UI stable** | Multi-page dist / v2.9.1 | [v2.9.1](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.1) |
 
-RC ModelScope example path:
+ModelScope RC example path:
 
 ```text
 releases/v2.9.2-rc.1-0813/Next-Trainer-v2.9.2-rc.1-0813-kohya-musubi.7z
 ```
 
-Legacy UI packages: [Releases](https://github.com/wochenlong/lora-scripts-next/releases) → **v2.9.1**.
-
----
-
-## How to use
-
-### A. Portable
-
-1. **Until 3.0.0 packs ship:** keep using the RC packages above for Vue 3 (sidebar may still say rc; source `dev` is already `3.0.0`)
-2. Extract to a path **without spaces or non-ASCII**; **lite** → `run_gui.bat`; full/split packs → follow in-archive launcher
-3. Open **http://127.0.0.1:28000**
-4. GA builds should show **`v3.0.0`** in the sidebar
-
-Requirements: Windows 10/11, NVIDIA GPU (RTX 20+ recommended).
+Needs Windows 10/11, NVIDIA GPU (RTX 20+ recommended); extract to a path without spaces or non-ASCII.
 
 More: [Portable getting started](docs/portable-getting-started.md) · [Tagger models](docs/tagger-models.md) · [Build & release (collaborators)](docs/portable-build-guide.md)
 
-### B. Run `dev` from source (Vue 3)
+---
+
+## Quick start
+
+### Portable
+
+1. Run `run_gui.bat` (or the launcher named in the archive)  
+2. Open **http://127.0.0.1:28000**  
+3. GA builds should show **`v3.0.0`** in the sidebar (RC may still show an rc badge)
+
+### Run current `main` from source (Vue 3)
 
 ```sh
 git clone https://github.com/wochenlong/lora-scripts-next.git
 cd lora-scripts-next
+git checkout main
+git pull
 
-git fetch origin
-git checkout dev
-git pull origin dev
-
-# Windows
 ./run_gui.bat
 # or: python gui.py --dev
 ```
 
 ```sh
-git branch --show-current   # should be dev
-cat VERSION                 # should be 3.0.0
+git branch --show-current   # main
+cat VERSION                 # 3.0.0
 ```
 
 Frontend lives in `frontend/` (Vue 3 + Vite):
@@ -75,11 +124,11 @@ Frontend lives in `frontend/` (Vue 3 + Vite):
 ```sh
 cd frontend
 npm install
-npm run dev      # hot reload (backend gui must be running)
-npm run build    # writes frontend/dist for static hosting
+npm run dev      # hot reload (backend must be running)
+npm run build    # writes frontend/dist
 ```
 
-### C. Switch an existing clone from `main` to `dev`
+### Follow the experiment line `dev`
 
 ```sh
 git fetch origin
@@ -87,63 +136,61 @@ git switch dev
 git pull
 ```
 
-Back to stable:
-
-```sh
-git switch main
-git pull
-```
-
-> **Note:** `main` and `dev` use different frontend architectures. Do not mix uncommitted `frontend/dist` hotfixes across branches. Portable users should use the package version as-is.
+> Do not mix uncommitted `frontend/dist` hotfixes across `main` / `dev` / `legacy`. Portable users should stay on the package version.
 
 ---
 
-## Vue 3 features (`dev` / 3.0.0)
-
-Compared with the legacy multi-page dist UI, **`dev` is a Vue 3 SPA workspace**:
+## Features
 
 | Area | Capabilities |
 |------|----------------|
 | **Training** | Base model × engine × target; live TOML preview; validate / import-export / start |
-| **Dataset** | WD14 tagging; **image-first tag editor** (toolbar source/load, filter & batch edit in a right panel) |
-| **Tasks** | Task list, status, logs, previews / Loss; primary place to watch runs |
-| **Settings** | UI prefs (incl. light/dark theme), **engine management** (Kohya / Anima Fast / Musubi), **download sources** (pip / PyTorch / HF / GitHub mirrors), About, changelog |
-| **Branding** | Product name **Next Trainer**; formal **`3.0.0`** (prerelease versions still show an **rc** badge) |
-| **Credits** | Settings → About; also [docs/credits.md](docs/credits.md) |
+| **Dataset** | WD14 tagging; image-first tag editor (filter & batch on the right) |
+| **Tasks** | List, status, logs, previews / Loss — primary place to watch runs |
+| **Settings** | Theme & UI, engine management (Kohya / Anima Fast / Musubi), download mirrors, About, changelog |
 
-Training backends:
+Backends: Anima LoRA / Fast / finetune, SD·SDXL, Flux (Kohya); optional **Krea 2** (Musubi). Plus local tagger, `/train-monitor`, TensorBoard.
 
-- Anima LoRA / Fast / finetune, SD/SDXL, Flux (Kohya line)
-- **Krea 2 LoRA** via optional **Musubi-Tuner** engine (install from Settings)
-- Local tagger, train monitor (`/train-monitor`), TensorBoard
-
-Anima Fast: [docs/anima-fast.md](docs/anima-fast.md) · Krea 2 multi-GPU (Linux): [docs/krea2-linux-multigpu.md](docs/krea2-linux-multigpu.md)
+- Anima Fast → [docs/anima-fast.md](docs/anima-fast.md)  
+- Krea 2 multi-GPU (Linux) → [docs/krea2-linux-multigpu.md](docs/krea2-linux-multigpu.md)
 
 ### Screenshots
 
-Captured from the `dev` Vue 3 UI (`3.0.0` line, Chinese locale).
+From the Vue 3 UI (`3.0.0` line, Chinese locale).
 
-#### Training
+<details open>
+<summary><strong>Training</strong></summary>
 
-| Standard (Kohya / Anima LoRA) | Anima Fast | Krea 2 (Musubi) |
+| Standard (Kohya / Anima) | Anima Fast | Krea 2 (Musubi) |
 |---|---|---|
 | ![Training · standard](assets/readme/vue3/01-training-standard.png) | ![Training · Fast](assets/readme/vue3/02-training-fast.png) | ![Training · Krea 2](assets/readme/vue3/08-training-krea2.png) |
 
-#### Dataset
+</details>
+
+<details>
+<summary><strong>Dataset</strong></summary>
 
 | Tagger | Tag editor |
 |---|---|
-| ![Dataset · tagger](assets/readme/vue3/03-dataset-tagger.png) | ![Dataset · editor](assets/readme/vue3/04-dataset-editor.png) |
+| ![Tagger](assets/readme/vue3/03-dataset-tagger.png) | ![Editor](assets/readme/vue3/04-dataset-editor.png) |
 
-#### Tasks
+</details>
+
+<details>
+<summary><strong>Tasks</strong></summary>
 
 ![Tasks](assets/readme/vue3/05-tasks.png)
 
-#### Settings
+</details>
+
+<details>
+<summary><strong>Settings</strong></summary>
 
 | UI prefs | Engines |
 |---|---|
 | ![Settings · UI](assets/readme/vue3/07-settings-ui.png) | ![Settings · engines](assets/readme/vue3/06-settings-engines.png) |
+
+</details>
 
 ---
 
@@ -156,9 +203,9 @@ Captured from the `dev` Vue 3 UI (`3.0.0` line, Chinese locale).
 | Anima finetune | Full DiT · ~24 GB recommended |
 | SD 1.5 / SDXL | LoRA / full finetune |
 | Flux | LoRA |
-| Krea 2 | LoRA via Musubi · install engine in Settings · multi-GPU on Linux |
+| Krea 2 | LoRA via Musubi · install in Settings · multi-GPU on Linux |
 
-See [docs/anima-training.md](docs/anima-training.md) for VRAM tips.
+VRAM tips: [docs/anima-training.md](docs/anima-training.md)
 
 ---
 
@@ -166,26 +213,35 @@ See [docs/anima-training.md](docs/anima-training.md) for VRAM tips.
 
 | Topic | Link |
 |------|------|
-| **Credits (subpage)** | [docs/credits.md](docs/credits.md) |
-| Full legal NOTICE | [NOTICE.md](NOTICE.md) |
+| Credits | [docs/credits.md](docs/credits.md) |
+| NOTICE | [NOTICE.md](NOTICE.md) |
 | Portable notes | [docs/portable-getting-started.md](docs/portable-getting-started.md) |
-| **Portable build & release (collaborators)** | [docs/portable-build-guide.md](docs/portable-build-guide.md) |
+| Build & release | [docs/portable-build-guide.md](docs/portable-build-guide.md) |
 | Tagger models | [docs/tagger-models.md](docs/tagger-models.md) |
-| Anima Fast | [docs/anima-fast.md](docs/anima-fast.md) |
-| **Krea 2 multi-GPU (Linux host + WebUI / `dev`)** | [docs/krea2-linux-multigpu.md](docs/krea2-linux-multigpu.md) |
 | Train monitor | [docs/train-monitor.md](docs/train-monitor.md) |
 | Repo layout | [docs/repo-layout.md](docs/repo-layout.md) |
 
 ---
 
-## FAQ (short)
+## FAQ
 
 **What to include in a bug report?**  
-Full version from the sidebar, train type (model/engine/target), steps to reproduce, logs. → [Issues](https://github.com/wochenlong/lora-scripts-next/issues)
+Full sidebar version, train type (model/engine/target), repro steps, logs. → [Issues](https://github.com/wochenlong/lora-scripts-next/issues)
 
 **lite vs kohya-musubi?**  
-Quick / weak network → lite (install deps on first run). Want Kohya + Musubi (Krea 2) ready → **kohya-musubi** (ModelScope). Anima Fast is install-from-Settings on both.
+Quick / weak network → lite (deps on first run). Want Kohya + Musubi (Krea 2) ready → **kohya-musubi**. Anima Fast installs from Settings on both.
+
+**UI completely changed after update?**  
+Expected: `main` is Vue 3 now. If you need the old UI, use [`legacy/v2.9.1`](https://github.com/wochenlong/lora-scripts-next/tree/legacy/v2.9.1) or the [v2.9.1 portable](https://github.com/wochenlong/lora-scripts-next/releases/tag/v2.9.1).
 
 ---
 
-<p align="center"><sub>Maintainer: <a href="https://github.com/wochenlong">@wochenlong</a> · <a href="docs/credits.md">Credits</a> · <a href="CONTRIBUTORS.md">Contributors</a></sub></p>
+<p align="center">
+  <sub>
+    Maintainer <a href="https://github.com/wochenlong">@wochenlong</a>
+    ·
+    <a href="docs/credits.md">Credits</a>
+    ·
+    <a href="CONTRIBUTORS.md">Contributors</a>
+  </sub>
+</p>


### PR DESCRIPTION
## Summary
- 开头说明 `main` 已切到 Vue 3（`3.0.0`）：改了什么、为什么改、什么没改
- 附上旧线回退：`legacy/v2.9.1`、标签 `legacy-v2.9.1-pre-vue3`、Release v2.9.1
- 中英文 README 整体重排（封面、分支表、下载、快速开始、折叠截图）

## Test plan
- [ ] 在 GitHub 预览 README / README-zh 渲染与图片路径
- [ ] 点击 legacy / tag / v2.9.1 链接可用