### PR TITLE
docs: README 增加计划中（Roadmap）清单

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -13,6 +13,8 @@
 <p align="center">
   <a href="README.md">English</a>
   ·
+  <a href="#计划中roadmap">计划中</a>
+  ·
   <a href="docs/credits.md">开源引用</a>
   ·
   <a href="CHANGELOG.md">更新日志</a>
@@ -165,6 +167,29 @@
 | ![设置界面](assets/readme/vue3/07-settings-ui.png) | ![设置引擎](assets/readme/vue3/06-settings-engines.png) |
 
 </details>
+
+---
+
+## 计划中（Roadmap）
+
+下面是公开路线图，**不保证排期**；具体进度以 [Issues](https://github.com/wochenlong/lora-scripts-next/issues) 为准。欢迎催更或补充场景。
+
+### 引擎与能力
+
+- [ ] 接入 [AI Toolkit](https://github.com/ostris/ai-toolkit)（更多新模型训练路径）
+- [ ] 接入 [DiffSynth-Studio](https://github.com/modelscope/DiffSynth-Studio)（文生图 LoRA 等）
+- [ ] 支持**图像编辑**类模型训练
+- [ ] 支持**视频**类模型训练
+
+### 模型与数据
+
+- [ ] **模型管理器**：按底模族默认推荐、本机优先、远程 ID 一键拉取到引擎原生布局
+- [ ] **API 打标**（对接外部打标 / 多模态接口）
+- [ ] **自然语言打标**（用自然语言描述生成 / 改写 caption）
+
+### 自动化
+
+- [ ] **Agent / API 接入**：把训练、任务状态做成可被程序调用的一环（模块化目标的一部分）
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 <p align="center">
   <a href="README-zh.md">中文</a>
   ·
+  <a href="#roadmap">Roadmap</a>
+  ·
   <a href="docs/credits.md">Credits</a>
   ·
   <a href="CHANGELOG.md">Changelog</a>
@@ -165,6 +167,29 @@ These shots are from the Vue 3 UI with the Chinese locale.
 | ![Settings UI](assets/readme/vue3/07-settings-ui.png) | ![Settings engines](assets/readme/vue3/06-settings-engines.png) |
 
 </details>
+
+---
+
+## Roadmap
+
+Public TODO list — **no hard dates**. Track progress on [Issues](https://github.com/wochenlong/lora-scripts-next/issues). Feedback and use-cases welcome.
+
+### Engines & capabilities
+
+- [ ] Plug in [AI Toolkit](https://github.com/ostris/ai-toolkit) (more training paths for newer models)
+- [ ] Plug in [DiffSynth-Studio](https://github.com/modelscope/DiffSynth-Studio) (e.g. text-to-image LoRA)
+- [ ] **Image-editing** model training
+- [ ] **Video** model training
+
+### Models & data
+
+- [ ] **Model manager**: per base-model-family defaults, local-first, remote ID → engine-native layout
+- [ ] **API tagging** (external / multimodal caption APIs)
+- [ ] **Natural-language tagging** (describe in plain language → captions)
+
+### Automation
+
+- [ ] **Agent / API hooks**: make training and task status callable from other tools (part of the modular goal)
 
 ---
 


### PR DESCRIPTION
## Summary
- 中英文 README 增加公开 Roadmap / TODO 清单（GitHub 可勾选样式）
- 覆盖：AI Toolkit、DiffSynth-Studio、模型管理器、API/自然语言打标、图像编辑与视频训练、Agent/API 接入
- 顶部导航增加「计划中 / Roadmap」锚点

## Test plan
- [ ] 打开仓库首页 README，确认 Roadmap 区块与锚点正常