### PR TITLE
docs: 训练表单分区通用排序骨架

### DIFF
--- a/docs/design/image-edit-dataset-contract.md
+++ b/docs/design/image-edit-dataset-contract.md
@@ -1,0 +1,92 @@
+# 设计约定 — 图像编辑训练数据集前端契约
+
+> **状态**：产品已拍板（2026-08-26）；本文只定**前端 / 磁盘契约**，引擎 adapter 另开实施。  
+> **关联**：[#252](https://github.com/wochenlong/lora-scripts-next/issues/252)（图像编辑训练 UI）；分区排序见 [`training-form-section-order.md`](./training-form-section-order.md)。  
+> **参考**：AI Toolkit 工作台 Target Dataset + Control Dataset（多目录同名配对）。
+
+---
+
+## 1. 产品口径（一句话）
+
+**不**加「文生图 / 图像编辑」模式切换。只在 **数据集设置** 里用路径是否填写来分流；磁盘布局与 **AI Toolkit 图像编辑数据集格式**对齐。Musubi（及后续引擎）须能消费这同一套目录格式开训。
+
+---
+
+## 2. 前端字段契约
+
+| 字段 | 类型 | 含义 |
+|------|------|------|
+| `train_data_dir` | `string`（必填） | **目标图**目录：要学成的图；caption 与目标图同名放此目录 |
+| `control_data_dirs` | `string[]`（可选） | **参考图**目录列表；与 AI Toolkit 多 Control 目录对齐 |
+
+### 2.1 任务判定（勿另开 task / tab）
+
+```text
+control_data_dirs 全空（或未出现）     → 文生图（无 input）
+control_data_dirs 有 ≥1 个非空路径     → 图像编辑（参考张数 = 非空路径数）
+```
+
+说明：
+
+- 无论文生图还是编辑，都**继续使用** `train_data_dir` 作为主数据集路径；**不要**把「出现了 `train_data_dir`」理解成「只能文生图」。
+- 单参考 = 数组长度 1；多参考 = 多个目录。不要并列维护互斥的单字段 `control_data_dir` 与另一套多路径 API。
+
+### 2.2 UI 形态
+
+- 数据集分区内：目标图路径（现有 filepicker）+「参考图目录 1 / 2 / …」可添加（建议默认最多展示/限制与引擎 capability 对齐，第一版可先 **最多 3** 路，与 AI Toolkit UI 一致）。
+- 文案提示：参考图与目标图 **同名配对**（扩展名可不同）；**参考图不需要 caption**；不填参考图则按文生图训练。
+- 训练预览：仅当存在参考图时，预览项可挂对应 control 图（细节随引擎实施）。
+
+### 2.3 明确不做（首期）
+
+- 「文生图 / 图像编辑」Tab 或第四维 `task` 切换。
+- Dataset 工作台内的配对浏览 / 拖拽对齐 UI（仍按 [#252](https://github.com/wochenlong/lora-scripts-next/issues/252)：训练页填路径即可）。
+- 为 Musubi 单独做「单目录 + `name_0.png`」的前端第二种布局。
+
+---
+
+## 3. 磁盘格式（与 AI Toolkit 对齐）
+
+用户准备的数据应为：
+
+```text
+targets/                 ← train_data_dir
+  photo001.png
+  photo001.txt           # caption / 编辑指令
+refs_a/                  ← control_data_dirs[0]
+  photo001.png           # 与目标同名，扩展名可不同
+refs_b/                  ← control_data_dirs[1]（多参考时）
+  photo001.png
+```
+
+配对规则：各 `control_data_dirs[i]` 内按 **basename 与目标图一致** 查找；找不到则提交前校验失败（或按产品后续规定抽样报错），禁止静默丢参考。
+
+---
+
+## 4. 引擎职责（预期，非本文实现）
+
+| 引擎 | 预期 |
+|------|------|
+| **AI Toolkit** | 前端字段几乎直通：`train_data_dir` → target/`folder_path`；`control_data_dirs` → `control_path` 列表 |
+| **Musubi** | **前端仍用上述契约与 AI Toolkit 目录格式**；adapter 负责把「多目录同名」可靠映射为 musubi 训练所需结构（例如生成 JSONL `control_path_0/1/…` 等）。产品预期：用户无需为 Musubi 另备 `_N` 单目录数据集 |
+
+上限、是否允许 0 张参考（Klein 可无 control；部分模型强制 control）由引擎 **capability** 下发或文档约定；前端按 capability 做必填/张数校验，不硬编码死在某一个模型名上（首期实现可先写死 Klein/Kontext 表，再收拢）。
+
+---
+
+## 5. 与分区排序的关系
+
+图像编辑**只扩展「数据集设置」**（及必要时「训练预览图设置」的 control 图），**不**新增「×× 专用 / 编辑」大分区。全站顺序仍以 [`training-form-section-order.md`](./training-form-section-order.md) 为准。
+
+---
+
+## 6. 落地清单（后续实施 PR）
+
+- [ ] Schema：对支持编辑的模型（如 Klein）在数据集区增加 `control_data_dirs`（数组 + filepicker）
+- [ ] 文案 / i18n：目标图 vs 参考图；同名配对说明
+- [ ] 提交前轻量校验：目录存在、抽样同名配对
+- [ ] Musubi adapter：消费 AI Toolkit 多目录格式并开训
+- [ ] AI Toolkit 引擎接入后：直通同一字段
+- [ ] 预览路径挂 control（有参考图时）
+
+协作：前端 [@IryNeko](https://github.com/IryNeko)；Musubi / 引擎映射 [@MikumikuDAIFans](https://github.com/MikumikuDAIFans)；产品口径 [@wochenlong](https://github.com/wochenlong)。

--- a/docs/design/image-edit-dataset-contract.md
+++ b/docs/design/image-edit-dataset-contract.md
@@ -1,14 +1,16 @@
 # 设计约定 — 图像编辑训练数据集前端契约
 
 > **状态**：产品已拍板（2026-08-26）；本文只定**前端 / 磁盘契约**，引擎 adapter 另开实施。  
-> **关联**：[#252](https://github.com/wochenlong/lora-scripts-next/issues/252)（图像编辑训练 UI）；分区排序见 [`training-form-section-order.md`](./training-form-section-order.md)。  
+> **关联**：[#252](https://github.com/wochenlong/lora-scripts-next/issues/252)（图像编辑训练 UI）；分区排序见 [`training-form-section-order.md`](./training-form-section-order.md)；引擎 [#284](https://github.com/wochenlong/lora-scripts-next/issues/284) / Klein [#299](https://github.com/wochenlong/lora-scripts-next/issues/299)。  
 > **参考**：AI Toolkit 工作台 Target Dataset + Control Dataset（多目录同名配对）。
 
 ---
 
 ## 1. 产品口径（一句话）
 
-**不**加「文生图 / 图像编辑」模式切换。只在 **数据集设置** 里用路径是否填写来分流；磁盘布局与 **AI Toolkit 图像编辑数据集格式**对齐。Musubi（及后续引擎）须能消费这同一套目录格式开训。
+**不**加「文生图 / 图像编辑」模式切换。只在 **数据集设置** 里用路径是否填写来分流；磁盘布局与 **AI Toolkit 图像编辑数据集格式**对齐。
+
+**引擎取向（2026-08-26）**：该契约的**首要消费者是 AI Toolkit**（下版本接入，后端先行）。Klein **不**再规划挂到 Musubi；其它引擎若日后消费同一磁盘布局，由各自 adapter 转换，前端不改第二套格式。
 
 ---
 
@@ -41,7 +43,7 @@ control_data_dirs 有 ≥1 个非空路径     → 图像编辑（参考张数 =
 
 - 「文生图 / 图像编辑」Tab 或第四维 `task` 切换。
 - Dataset 工作台内的配对浏览 / 拖拽对齐 UI（仍按 [#252](https://github.com/wochenlong/lora-scripts-next/issues/252)：训练页填路径即可）。
-- 为 Musubi 单独做「单目录 + `name_0.png`」的前端第二种布局。
+- 为其它引擎单独做第二套前端目录布局（一律 AI Toolkit 多目录契约）。
 
 ---
 
@@ -67,8 +69,8 @@ refs_b/                  ← control_data_dirs[1]（多参考时）
 
 | 引擎 | 预期 |
 |------|------|
-| **AI Toolkit** | 前端字段几乎直通：`train_data_dir` → target/`folder_path`；`control_data_dirs` → `control_path` 列表 |
-| **Musubi** | **前端仍用上述契约与 AI Toolkit 目录格式**；adapter 负责把「多目录同名」可靠映射为 musubi 训练所需结构（例如生成 JSONL `control_path_0/1/…` 等）。产品预期：用户无需为 Musubi 另备 `_N` 单目录数据集 |
+| **AI Toolkit（首选）** | 前端字段几乎直通：`train_data_dir` → target/`folder_path`；`control_data_dirs` → `control_path` 列表（见 #284 / #299） |
+| **其它引擎（可选）** | 若消费同一磁盘布局，adapter 自行映射；**不**为 Klein 单独往 Musubi 再叠一套编辑栈 |
 
 上限、是否允许 0 张参考（Klein 可无 control；部分模型强制 control）由引擎 **capability** 下发或文档约定；前端按 capability 做必填/张数校验，不硬编码死在某一个模型名上（首期实现可先写死 Klein/Kontext 表，再收拢）。
 
@@ -85,8 +87,7 @@ refs_b/                  ← control_data_dirs[1]（多参考时）
 - [ ] Schema：对支持编辑的模型（如 Klein）在数据集区增加 `control_data_dirs`（数组 + filepicker）
 - [ ] 文案 / i18n：目标图 vs 参考图；同名配对说明
 - [ ] 提交前轻量校验：目录存在、抽样同名配对
-- [ ] Musubi adapter：消费 AI Toolkit 多目录格式并开训
-- [ ] AI Toolkit 引擎接入后：直通同一字段
+- [ ] AI Toolkit 引擎 + adapter：直通同一字段（#284 / #299，**后端先行**）
 - [ ] 预览路径挂 control（有参考图时）
 
-协作：前端 [@IryNeko](https://github.com/IryNeko)；Musubi / 引擎映射 [@MikumikuDAIFans](https://github.com/MikumikuDAIFans)；产品口径 [@wochenlong](https://github.com/wochenlong)。
+协作：引擎 / 后端 [@MikumikuDAIFans](https://github.com/MikumikuDAIFans)、[@IryNeko](https://github.com/IryNeko)；产品 / 前端 [@wochenlong](https://github.com/wochenlong)。

--- a/docs/design/training-form-section-order.md
+++ b/docs/design/training-form-section-order.md
@@ -81,7 +81,7 @@
 
 | 场景 | 字段落点 |
 |------|----------|
-| Klein / Kontext / Qwen-Edit 等 | 参考图 → **数据集** 的 `control_data_dirs[]`（与 AI Toolkit 目录格式对齐，见 [`image-edit-dataset-contract.md`](./image-edit-dataset-contract.md)）；预览 control → **训练预览**；不新开「编辑」大分区 |
+| Klein / Kontext / Qwen-Edit 等 | 参考图 → **数据集** 的 `control_data_dirs[]`（与 AI Toolkit 目录格式对齐，见 [`image-edit-dataset-contract.md`](./image-edit-dataset-contract.md)）；预览 control → **训练预览**；不新开「编辑」大分区。Klein 下版本走 **AI Toolkit**（#284 / #299），不挂 Musubi |
 | 视频（Wan 等） | `num_frames` / fps → **数据集** |
 | 音频 | 路径与长度类 → **数据集** |
 | 全量微调 | **网络设置**整段隐藏 |

--- a/docs/design/training-form-section-order.md
+++ b/docs/design/training-form-section-order.md
@@ -30,7 +30,7 @@
 |----|--------|--------|--------|
 | 1 | **训练用模型** | 底模及配套权重路径（VAE / TE / AE…）、resume | 否 |
 | 2 | **训练模型类型** | 身份选择：预测类型、`lora_type`（lora/lokr…）、flux/chroma、`model_version` 等 | 可空（无类型开关时隐藏整段） |
-| 3 | **数据集设置** | 目标图目录、分辨率/桶、caption 后缀；编辑能力时**可选**参考图（Control）目录 | 否 |
+| 3 | **数据集设置** | 目标图目录、分辨率/桶、caption 后缀；编辑能力时用 **`control_data_dirs[]`**（AI Toolkit 多目录同名格式，详见 [`image-edit-dataset-contract.md`](./image-edit-dataset-contract.md)） | 否 |
 | 4 | **保存设置** | output 名/目录、保存频率与精度 | 否 |
 | 5 | **训练过程** | epoch / steps / batch / seed；时间步与损失调度（原「专用」里的 timestep / shift / CFG / token 长度等） | 否 |
 | 6 | **学习率与优化器** | lr、scheduler、optimizer | 否 |
@@ -81,7 +81,7 @@
 
 | 场景 | 字段落点 |
 |------|----------|
-| Klein / Kontext / Qwen-Edit 等 | 参考图路径 → **数据集**；预览 control → **训练预览**；不新开「编辑」大分区 |
+| Klein / Kontext / Qwen-Edit 等 | 参考图 → **数据集** 的 `control_data_dirs[]`（与 AI Toolkit 目录格式对齐，见 [`image-edit-dataset-contract.md`](./image-edit-dataset-contract.md)）；预览 control → **训练预览**；不新开「编辑」大分区 |
 | 视频（Wan 等） | `num_frames` / fps → **数据集** |
 | 音频 | 路径与长度类 → **数据集** |
 | 全量微调 | **网络设置**整段隐藏 |
@@ -107,6 +107,7 @@ Musubi / AI Toolkit 的 CLI 或上游 UI 卡片顺序可以不同；**Next Train
 
 ## 6. 相关
 
+- [`image-edit-dataset-contract.md`](./image-edit-dataset-contract.md) — 图像编辑数据集前端契约（AI Toolkit 多目录格式；Musubi 同格式消费）
 - [`schema-form-single-column.md`](./schema-form-single-column.md) — 表单单列（布局，不改分区语义）
 - [`selector-feedback-and-draft-carryover.md`](./selector-feedback-and-draft-carryover.md) — 选择器与草稿携带
 - 团队分工：产品 IA [@wochenlong](https://github.com/wochenlong)；前端落地 [@IryNeko](https://github.com/IryNeko)；引擎侧字段映射 [@MikumikuDAIFans](https://github.com/MikumikuDAIFans)

--- a/docs/design/training-form-section-order.md
+++ b/docs/design/training-form-section-order.md
@@ -1,0 +1,112 @@
+# 设计约定 — 训练表单分区通用排序骨架
+
+> **状态**：产品已拍板（2026-08-26），本 PR 仅落文档；各 `mikazuki/schema/*.ts` 落地改动另开实施 PR。  
+> **范围**：训练工作台 Schema 表单的**分区顺序与字段归属心智**；适用于现有 Kohya / Anima Fast / Musubi，以及后续 AI Toolkit 等引擎接入的模型。  
+> **关联**：产品 IA [#215](https://github.com/wochenlong/lora-scripts-next/issues/215)；跟踪 Issue [#297](https://github.com/wochenlong/lora-scripts-next/issues/297)。
+
+---
+
+## 1. 目标
+
+培养统一用户心智：
+
+1. **开头必定是「训练用模型」**（选底模 / 填路径）。
+2. **结尾必定是「分布式训练」**（多卡 / 多机；引擎暂不支持也保留同名位，勿换别的结尾）。
+3. **取消「×× 专用参数」分区**，字段拆进对应格子，禁止插在数据集前面。
+
+操作主路径对齐：
+
+```text
+选模型 → 选类型 → 模型路径 → 数据集路径 → …… → 分布式
+```
+
+以现有 Kohya SDXL（`lora-master`）为参考骨架，向全站推广。
+
+---
+
+## 2. 全站固定顺序（硬规矩）
+
+| 序 | 分区名 | 放什么 | 可空？ |
+|----|--------|--------|--------|
+| 1 | **训练用模型** | 底模及配套权重路径（VAE / TE / AE…）、resume | 否 |
+| 2 | **训练模型类型** | 身份选择：预测类型、`lora_type`（lora/lokr…）、flux/chroma、`model_version` 等 | 可空（无类型开关时隐藏整段） |
+| 3 | **数据集设置** | 目标图目录、分辨率/桶、caption 后缀；编辑能力时**可选**参考图（Control）目录 | 否 |
+| 4 | **保存设置** | output 名/目录、保存频率与精度 | 否 |
+| 5 | **训练过程** | epoch / steps / batch / seed；时间步与损失调度（原「专用」里的 timestep / shift / CFG / token 长度等） | 否 |
+| 6 | **学习率与优化器** | lr、scheduler、optimizer | 否 |
+| 7 | **网络设置** | dim / alpha / LyCORIS 细节、续训权重等 | 可空（全量微调无 LoRA 时隐藏） |
+| 8 | **训练预览图设置** | enable_preview、sample prompts、间隔；编辑模型可挂预览用参考图 | 可空（引擎无采样时隐藏） |
+| 9 | **省显存** | 梯度检查点、fp8、blocks_to_swap、attn、compile、cache 等 | 建议保留 |
+| 10 | **日志 / caption / 噪声 / 数据增强**（若仍有独立用户任务） | 各自独立分区，顺序紧挨「其他」之前 | 可空 |
+| 11 | **其他** | 收纳箱（见 §3） | 建议保留 |
+| 12 | **分布式训练** | 多卡 / 多机；**永远最后一格** | 保留空位（不支持则灰掉说明） |
+
+### 2.1 禁止
+
+- 禁止再出现「Anima 专用参数 / Flux 专用参数 / Krea 2 专用参数」这类插在数据集前的整块分区。
+- 禁止把预览、日志、caption 等已独立任务塞回「其他」却仍占独立标题空壳。
+- 禁止用别的分区替换「分布式训练」作为表单结尾。
+
+### 2.2 原「×× 专用参数」拆分归属
+
+| 字段类型 | 落到 |
+|----------|------|
+| 类型开关（lokr、SDXL 预测类型、flux/chroma、klein `model_version`…） | **训练模型类型** |
+| timestep / shift / sigmoid / weighting / CFG / token 长度 | **训练过程** |
+| attn / compile / VAE chunk / offload / blocks_to_swap / fp8… | **省显存** |
+
+---
+
+## 3. 「其他」= 收纳箱
+
+定位：暂时归不进前几格、又不够单独开板块的尾巴字段。
+
+### 3.1 箱内排序（按对训练结果的影响从强到弱）
+
+1. **数据怎么进模型** — caption shuffle / dropout、token 保留、clip_skip、加权 caption 等（若未升格独立分区）  
+2. **噪声与目标扰动** — noise_offset、multires noise 等  
+3. **数据增强** — flip、color aug 等  
+4. **可复现与杂项训练开关** — 未进「训练过程」的 seed 等  
+5. **日志与追踪** — TensorBoard / wandb（若未独立）  
+6. **调试与实验** — profile、nan check、debug mode 等  
+7. **纯 UI / 透传** — `ui_custom_params` 等  
+
+规则：用户能说出「我要去调 XX」→ **单独分区**；说不清、很少动 → **其他**。某类长大后从「其他」**升格**为独立分区，插在「其他」前；「其他」本身不改名、不挪到分布式后。
+
+---
+
+## 4. 跨引擎适用性（通用）
+
+本骨架不绑定单一引擎。后续模型只增减字段，**不改分区顺序**。
+
+| 场景 | 字段落点 |
+|------|----------|
+| Klein / Kontext / Qwen-Edit 等 | 参考图路径 → **数据集**；预览 control → **训练预览**；不新开「编辑」大分区 |
+| 视频（Wan 等） | `num_frames` / fps → **数据集** |
+| 音频 | 路径与长度类 → **数据集** |
+| 全量微调 | **网络设置**整段隐藏 |
+| 引擎暂无分布式 | 最后一格保留并说明不支持 |
+
+Musubi / AI Toolkit 的 CLI 或上游 UI 卡片顺序可以不同；**Next Trainer 工作台以本约定为准**（先模型路径与数据集，再训练过程，最后分布式）。
+
+---
+
+## 5. 落地范围（后续实施 PR，非本文）
+
+按本约定调整（示例，以实施 PR 为准）：
+
+- `mikazuki/schema/sd3-lora.ts`、`anima-lora-fast.ts`、`anima-finetune.ts`
+- `mikazuki/schema/flux-lora.ts`、`lumina2-lora.ts`、`krea2-lora.ts`
+- 对齐时顺带核对 `lora-master.ts` / `dreambooth.ts`（SDXL 大体已近标准；`gradient_checkpointing` 等应从「训练相关」挪到「省显存」）
+- 前端 TOC / i18n 分区标题与 schema `.description()` 一致
+- 无行为变更的纯顺序调整；默认值与校验语义保持不变
+
+验收：打开各训练入口，分区 TOC 顺序与上表一致；数据集紧跟模型路径区；无「×× 专用参数」；末格为分布式。
+
+---
+
+## 6. 相关
+
+- [`schema-form-single-column.md`](./schema-form-single-column.md) — 表单单列（布局，不改分区语义）
+- [`selector-feedback-and-draft-carryover.md`](./selector-feedback-and-draft-carryover.md) — 选择器与草稿携带
+- 团队分工：产品 IA [@wochenlong](https://github.com/wochenlong)；前端落地 [@IryNeko](https://github.com/IryNeko)；引擎侧字段映射 [@MikumikuDAIFans](https://github.com/MikumikuDAIFans)


### PR DESCRIPTION
## Summary

- 新增训练表单分区**通用排序骨架**设计文档：docs/design/training-form-section-order.md
- 硬规矩：开头「训练用模型」、结尾「分布式训练」；取消「×× 专用参数」；「其他」= 收纳箱（箱内按对训练影响排序）
- 明确适用于现有 Kohya / Fast / Musubi，以及后续 AI Toolkit 等接入模型（格子可空，不改顺序）
- 跟踪 Issue：#297（schema 落地另开实施 PR）

## 请协助确认

cc @IryNeko（前端 / dev 落地时按此对齐 TOC 与 schema 分区）
cc @MikumikuDAIFans（引擎侧字段映射进对应格子，勿再开专用插队分区）
cc @wochenlong（产品 IA 定稿确认）

## Test plan

- [ ] 文档路径与链接可读
- [ ] 与 #215 / #297 交叉引用正确
- [ ] 合入后实施 PR 再改 mikazuki/schema/*.ts（本 PR 无代码行为变更）
