### PR TITLE
fix(engines): let installers use the uv cache by default

### DIFF
--- a/clear_cache.bat
+++ b/clear_cache.bat
@@ -1,0 +1,35 @@
+@echo off
+chcp 65001 >nul 2>&1
+title Clear uv download cache
+cd /d "%~dp0"
+
+REM Clear the uv global cache (%%LOCALAPPDATA%%\uv\cache).
+REM
+REM Engine installers (Anima Fast / Musubi / AI Toolkit) use the uv cache by
+REM default so reinstalls and sibling engines share multi-GB downloads (torch
+REM etc.). Run this script when you need the disk space back.
+
+echo.
+echo  ============================================
+echo   Clear uv download cache
+echo  ============================================
+echo.
+
+where uv >nul 2>&1
+if errorlevel 1 (
+    echo  [ERROR] uv not found in PATH.
+    echo  Install uv first ^(https://docs.astral.sh/uv/^), or remove the cache
+    echo  directory manually: rmdir /s /q "%LOCALAPPDATA%\uv\cache"
+    echo.
+    pause
+    exit /b 1
+)
+
+uv cache info
+echo.
+echo  Cleaning...
+uv cache clean
+echo.
+echo  Done. Engine reinstalls will download dependencies again on next install.
+echo.
+pause

--- a/clear_cache.sh
+++ b/clear_cache.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Clear the uv global cache (~/.cache/uv).
+#
+# Engine installers (Anima Fast / Musubi / AI Toolkit) use the uv cache by
+# default so reinstalls and sibling engines share multi-GB downloads (torch
+# etc.). Run this script when you need the disk space back.
+
+set -e
+
+cd "$(dirname "$0")"
+
+echo ""
+echo "  ============================================"
+echo "   Clear uv download cache (Linux)"
+echo "  ============================================"
+echo ""
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "  [ERROR] uv not found in PATH."
+    echo "  Install uv first (https://docs.astral.sh/uv/), or remove the cache"
+    echo "  directory manually: rm -rf ~/.cache/uv"
+    echo ""
+    exit 1
+fi
+
+uv cache info || true
+echo ""
+echo "  Cleaning..."
+uv cache clean
+echo ""
+echo "  Done. Engine reinstalls will download dependencies again on next install."
+echo ""

--- a/mikazuki/engines/ai_toolkit/environment.py
+++ b/mikazuki/engines/ai_toolkit/environment.py
@@ -458,7 +458,7 @@ def install_environment(
     if not base_python.is_file():
         plan.python_install_dir.mkdir(parents=True, exist_ok=True)
         _run_streaming(
-            [uv, "python", "install", TOOLKIT_PYTHON_VERSION, "--install-dir", str(plan.python_install_dir), "--no-cache"],
+            [uv, "python", "install", TOOLKIT_PYTHON_VERSION, "--install-dir", str(plan.python_install_dir)],
             plan.project_root,
             log,
             env=process_env,
@@ -497,7 +497,6 @@ def install_environment(
             "install",
             "--python",
             str(plan.venv_python),
-            "--no-cache",
             "--no-config",
             "--index-url",
             torch_index,
@@ -520,7 +519,6 @@ def install_environment(
             "install",
             "--python",
             str(plan.venv_python),
-            "--no-cache",
             "--no-config",
             "--index-url",
             pip_index,

--- a/mikazuki/engines/anima_fast/environment.py
+++ b/mikazuki/engines/anima_fast/environment.py
@@ -477,7 +477,7 @@ def install_environment(
     if not base_python.is_file():
         plan.python_install_dir.mkdir(parents=True, exist_ok=True)
         _run_streaming(
-            [uv, "python", "install", "3.13", "--install-dir", str(plan.python_install_dir), "--reinstall", "--no-cache"],
+            [uv, "python", "install", "3.13", "--install-dir", str(plan.python_install_dir), "--reinstall"],
             plan.project_root,
             log,
             env=process_env,
@@ -516,7 +516,6 @@ def install_environment(
             "install",
             "--python",
             str(plan.venv_python),
-            "--no-cache",
             "--no-config",
             "--index-url",
             pip_index,

--- a/mikazuki/engines/musubi/environment.py
+++ b/mikazuki/engines/musubi/environment.py
@@ -399,7 +399,7 @@ def install_environment(
     if not base_python.is_file():
         plan.python_install_dir.mkdir(parents=True, exist_ok=True)
         _run_streaming(
-            [uv, "python", "install", MUSUBI_PYTHON_VERSION, "--install-dir", str(plan.python_install_dir), "--no-cache"],
+            [uv, "python", "install", MUSUBI_PYTHON_VERSION, "--install-dir", str(plan.python_install_dir)],
             plan.project_root,
             log,
             env=process_env,
@@ -434,7 +434,6 @@ def install_environment(
             "install",
             "--python",
             str(plan.venv_python),
-            "--no-cache",
             "--no-config",
             "--index-url",
             pip_index,

--- a/tests/test_cli_entrypoints.py
+++ b/tests/test_cli_entrypoints.py
@@ -43,3 +43,20 @@ def test_readme_and_cli_docs_explain_anima_cli_entrypoints():
 
     assert "qwen3" in cli_docs
     assert "qwen3" in anima_docs
+
+
+def test_engine_installers_use_uv_cache_by_default():
+    for path in (
+        "mikazuki/engines/anima_fast/environment.py",
+        "mikazuki/engines/musubi/environment.py",
+        "mikazuki/engines/ai_toolkit/environment.py",
+    ):
+        assert '"--no-cache"' not in read(path), path
+
+
+def test_clear_cache_scripts_exist_and_call_uv_cache_clean():
+    sh = read("clear_cache.sh")
+    bat = read("clear_cache.bat")
+
+    assert "uv cache clean" in sh
+    assert "uv cache clean" in bat


### PR DESCRIPTION
优先工作，提供手动删除cache选项，移除--no-cache实现
之后请使用clear_cache.bat/sh来手动清cache