### PR TITLE
fix(gui): prevent helper process leaks

### DIFF
--- a/config/anima_fast_environment/main-constraints-cu130.txt
+++ b/config/anima_fast_environment/main-constraints-cu130.txt
@@ -9,4 +9,3 @@ transformers==4.51.3
 fastapi==0.95.1
 uvicorn==0.22.0
 tensorboard==2.10.1
-gradio==3.44.2

--- a/gui.py
+++ b/gui.py
@@ -1,9 +1,11 @@
 import argparse
+import importlib.util
 import locale
 import os
 import platform
 import subprocess
 import sys
+import time
 
 from mikazuki.launch_utils import (base_dir_path, catch_exception, git_tag,
                                    prepare_environment, check_port_avaliable,
@@ -18,11 +20,11 @@ parser.add_argument("--listen", action="store_true")
 parser.add_argument("--skip-prepare-environment", action="store_true")
 parser.add_argument("--skip-prepare-onnxruntime", action="store_true")
 parser.add_argument("--disable-tensorboard", action="store_true", default=False)
-parser.add_argument("--disable-tageditor", action="store_true")
+parser.add_argument("--disable-tageditor", action="store_true", help=argparse.SUPPRESS)
 parser.add_argument(
     "--enable-legacy-tageditor",
     action="store_true",
-    help="Deprecated compatibility flag. Legacy Gradio Dataset Tag Editor now starts by default.",
+    help="Start the optional legacy Gradio Dataset Tag Editor.",
 )
 parser.add_argument("--disable-train-monitor", action="store_true")
 parser.add_argument("--disable-auto-mirror", action="store_true")
@@ -34,6 +36,17 @@ parser.add_argument("--browser", type=str, default=None,
                     choices=["chrome", "edge", "default"],
                     help="Browser to open GUI: chrome, edge, or default (system default)")
 parser.add_argument("--dev", action="store_true")
+
+
+def _popen(command: list[str], **kwargs) -> subprocess.Popen:
+    if sys.platform.startswith("linux"):
+        command = [
+            sys.executable,
+            str(base_dir_path() / "mikazuki" / "child_process.py"),
+            str(os.getpid()),
+            *command,
+        ]
+    return subprocess.Popen(command, **kwargs)
 
 
 def ensure_port_available(
@@ -63,14 +76,14 @@ def ensure_port_available(
 @catch_exception
 def run_train_monitor():
     env = os.environ.copy()
-    subprocess.Popen([sys.executable, str(base_dir_path() / "train_monitor" / "server.py")], env=env)
+    return _popen([sys.executable, str(base_dir_path() / "train_monitor" / "server.py")], env=env)
 
 
 @catch_exception
 def run_tensorboard():
     log.info("Starting tensorboard...")
-    subprocess.Popen([sys.executable, "-m", "tensorboard.main", "--logdir", "logs",
-                     "--host", args.tensorboard_host, "--port", str(args.tensorboard_port)])
+    return _popen([sys.executable, "-m", "tensorboard.main", "--logdir", "logs",
+                   "--host", args.tensorboard_host, "--port", str(args.tensorboard_port)])
 
 
 @catch_exception
@@ -97,6 +110,12 @@ def run_tag_editor(port: int):
                 "自动初始化失败，请手动执行 git submodule update --init。"
             )
             return
+    if importlib.util.find_spec("gradio") is None:
+        log.error(
+            "Legacy Dataset Tag Editor requires the optional Gradio dependency. "
+            "Install mikazuki/dataset-tag-editor/requirements.txt before enabling it."
+        )
+        return None
     log.info("Starting tageditor...")
     tag_args = [
         "--port", str(port),
@@ -115,7 +134,53 @@ def run_tag_editor(port: int):
         f"sys.argv = [{str(launch_script)!r}] + {tag_args!r};"
         f"exec(compile(open({str(launch_script)!r}).read(), {str(launch_script)!r}, 'exec'))"
     )
-    subprocess.Popen([sys.executable, "-s", "-c", bootstrap])
+    return _popen([sys.executable, "-s", "-c", bootstrap])
+
+
+def stop_child_processes(
+    processes: list[tuple[str, subprocess.Popen]], timeout: float = 5.0
+) -> None:
+    running = []
+    for name, process in processes:
+        try:
+            if process.poll() is None:
+                running.append((name, process))
+        except Exception as e:
+            log.warning(f"Could not inspect {name} process: {e}")
+    if not running:
+        return
+
+    for name, process in running:
+        log.info(f"Stopping {name} (PID {process.pid})...")
+        try:
+            process.terminate()
+        except Exception as e:
+            log.warning(f"Could not terminate {name} (PID {process.pid}): {e}")
+
+    deadline = time.monotonic() + timeout
+    remaining = []
+    for name, process in running:
+        try:
+            process.wait(timeout=max(0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            remaining.append((name, process))
+        except Exception as e:
+            log.warning(f"Could not wait for {name} (PID {process.pid}): {e}")
+            remaining.append((name, process))
+
+    for name, process in remaining:
+        log.warning(f"{name} did not stop in time; killing PID {process.pid}.")
+        try:
+            process.kill()
+        except ProcessLookupError:
+            continue
+        except Exception as e:
+            log.warning(f"Could not kill {name} (PID {process.pid}): {e}")
+            continue
+        try:
+            process.wait()
+        except Exception as e:
+            log.warning(f"Could not reap {name} (PID {process.pid}): {e}")
 
 
 def launch():
@@ -129,7 +194,7 @@ def launch():
     log.info("Starting SD-Trainer Mikazuki GUI...")
     log.info(f"Base directory: {base_dir_path()}, Working directory: {os.getcwd()}")
     log.info(f"{platform.system()} Python {platform.python_version()} {sys.executable}")
-    legacy_tageditor_enabled = not args.disable_tageditor
+    legacy_tageditor_enabled = args.enable_legacy_tageditor and not args.disable_tageditor
 
     if not args.skip_prepare_environment:
         prepare_environment(disable_auto_mirror=args.disable_auto_mirror,
@@ -198,24 +263,34 @@ def launch():
     if args.browser:
         os.environ["MIKAZUKI_BROWSER"] = args.browser
 
-    if legacy_tageditor_enabled:
-        run_tag_editor(tageditor_port)
-    else:
-        log.info("Using native dataset editor at /dataset-editor.html; legacy Gradio tag editor is disabled.")
+    child_processes: list[tuple[str, subprocess.Popen]] = []
+    try:
+        if legacy_tageditor_enabled:
+            process = run_tag_editor(tageditor_port)
+            if process is not None:
+                child_processes.append(("legacy tag editor", process))
+        else:
+            log.info("Using native dataset editor at /dataset-editor.html; legacy Gradio tag editor is disabled.")
 
-    if not args.disable_tensorboard:
-        run_tensorboard()
+        if not args.disable_tensorboard:
+            process = run_tensorboard()
+            if process is not None:
+                child_processes.append(("TensorBoard", process))
 
-    if not args.disable_train_monitor:
-        run_train_monitor()
+        if not args.disable_train_monitor:
+            process = run_train_monitor()
+            if process is not None:
+                child_processes.append(("train monitor", process))
 
-    import uvicorn
-    log.info(f"Server started at http://{args.host}:{args.port}")
-    if not args.disable_train_monitor:
-        log.info(f"Train monitor at http://{args.host}:{args.train_monitor_port}")
-    else:
-        log.info("Train monitor disabled (--disable-train-monitor)")
-    uvicorn.run("mikazuki.app:app", host=args.host, port=args.port, log_level="error", reload=args.dev)
+        import uvicorn
+        log.info(f"Server started at http://{args.host}:{args.port}")
+        if not args.disable_train_monitor:
+            log.info(f"Train monitor at http://{args.host}:{args.train_monitor_port}")
+        else:
+            log.info("Train monitor disabled (--disable-train-monitor)")
+        uvicorn.run("mikazuki.app:app", host=args.host, port=args.port, log_level="error", reload=args.dev)
+    finally:
+        stop_child_processes(child_processes)
 
 
 if __name__ == "__main__":

--- a/mikazuki/child_process.py
+++ b/mikazuki/child_process.py
@@ -1,0 +1,31 @@
+"""Linux child launcher that terminates when its creating parent disappears."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import signal
+import sys
+
+
+def main() -> None:
+    parent_pid = int(sys.argv[1])
+    command = sys.argv[2:]
+    if not command:
+        raise SystemExit("missing child command")
+
+    signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGTERM})
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(1, signal.SIGTERM) != 0:  # PR_SET_PDEATHSIG
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+
+    # The parent can disappear between Popen() and prctl().
+    if os.getppid() != parent_pid:
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    os.execvpe(command[0], command, os.environ)
+
+
+if __name__ == "__main__":
+    main()

--- a/mikazuki/launch_utils.py
+++ b/mikazuki/launch_utils.py
@@ -207,7 +207,7 @@ def _parse_env_marker(line: str):
 
 
 def validate_requirements(requirements_file: str):
-    with open(requirements_file, 'r', encoding='utf8') as f:
+    with open(requirements_file, 'r', encoding='utf-8-sig') as f:
         lines = [
             line.strip()
             for line in f.readlines()
@@ -252,7 +252,7 @@ def ensure_requirements_installed(requirements_file: str = "requirements.txt") -
         return
 
     try:
-        with open(req_path, "r", encoding="utf8") as f:
+        with open(req_path, "r", encoding="utf-8-sig") as f:
             raw_lines = f.readlines()
     except OSError as e:
         log.warning(f"could not read {req_path}: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-accelerate==0.33.0
+﻿accelerate==0.33.0
 transformers==4.51.3
 diffusers[torch]==0.33.1
 ftfy==6.1.1
@@ -38,10 +38,9 @@ scipy
 requests
 pillow
 numpy==1.26.4
-# <=2.0.0
-gradio==3.44.2
 fastapi==0.95.1
 uvicorn==0.22.0
+websockets==11.0.3
 wandb==0.16.2
 httpx==0.24.1
 # extra

--- a/setup_environment.py
+++ b/setup_environment.py
@@ -144,7 +144,7 @@ def _missing_requirements():
         "    if name:\n"
         "        installed.add(name)\n"
         "missing = []\n"
-        "with open(sys.argv[1], 'r', encoding='utf-8') as f:\n"
+        "with open(sys.argv[1], 'r', encoding='utf-8-sig') as f:\n"
         "    for raw in f:\n"
         "        line = raw.strip()\n"
         "        if not line or line.startswith('#') or line.startswith('-'):\n"
@@ -195,7 +195,7 @@ def check_already_installed(quiet=False):
     if not os.path.isdir(torch_dir):
         return False
 
-    core_modules = ("torch", "torchvision", "accelerate", "diffusers", "gradio")
+    core_modules = ("torch", "torchvision", "accelerate", "diffusers")
     for module in core_modules:
         try:
             __import__(module)
@@ -374,7 +374,7 @@ def _filter_requirements(req_file):
     """Read requirements.txt, filtering out packages incompatible with embedded Python."""
     skip_packages = {"triton-windows", "triton"}
     filtered_path = req_file + ".filtered"
-    with open(req_file, "r", encoding="utf-8") as f:
+    with open(req_file, "r", encoding="utf-8-sig") as f:
         lines = f.readlines()
     with open(filtered_path, "w", encoding="utf-8") as f:
         for line in lines:
@@ -438,7 +438,7 @@ def _core_modules_ok():
     )
     if not os.path.isdir(torch_dir):
         return False
-    for module in ("torch", "torchvision", "accelerate", "diffusers", "gradio"):
+    for module in ("torch", "torchvision", "accelerate", "diffusers"):
         try:
             __import__(module)
         except Exception:
@@ -527,7 +527,7 @@ def main():
 
     # 4 — requirements
     _separator()
-    _step(4, "安装训练组件 (transformers, diffusers, gradio ...)")
+    _step(4, "安装训练组件 (transformers, diffusers ...)")
     print()
     if not install_requirements(region):
         _fail("训练组件安装失败，请检查网络连接后重新运行 run_gui.bat")

--- a/tests/test_dataset_editor_api.py
+++ b/tests/test_dataset_editor_api.py
@@ -331,11 +331,11 @@ def test_dataset_editor_rejects_path_escape(tmp_path):
     assert "outside dataset" in response.json()["detail"]
 
 
-def test_legacy_gradio_tageditor_starts_by_default_for_existing_users():
+def test_legacy_gradio_tageditor_is_opt_in():
     gui = (ROOT / "gui.py").read_text(encoding="utf-8")
 
     assert "--enable-legacy-tageditor" in gui
-    assert "legacy_tageditor_enabled = not args.disable_tageditor" in gui
+    assert "legacy_tageditor_enabled = args.enable_legacy_tageditor" in gui
     assert "run_tag_editor(tageditor_port)" in gui
 
 

--- a/tests/test_gui_lifecycle.py
+++ b/tests/test_gui_lifecycle.py
@@ -95,9 +95,9 @@ def test_linux_child_exits_when_parent_is_killed_from_another_directory(tmp_path
             sys.executable,
             "-c",
             (
-                "import os,signal,sys,time; from gui import _popen; "
+                "import os,signal,subprocess,sys,time; from gui import _popen; "
                 "signal.pthread_sigmask(signal.SIG_BLOCK,{signal.SIGTERM}); "
-                "child=_popen([sys.executable,'-c','import time; time.sleep(60)']); "
+                "child=_popen([sys.executable,'-c','import time; time.sleep(60)'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); "
                 "print(child.pid, flush=True); time.sleep(0.2); os._exit(0)"
             ),
         ],

--- a/tests/test_gui_lifecycle.py
+++ b/tests/test_gui_lifecycle.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+from unittest import mock
+
+import gui
+
+
+class FakeProcess:
+    def __init__(
+        self, pid: int, *, running: bool = True, times_out: bool = False,
+        wait_error: Exception | None = None
+    ):
+        self.pid = pid
+        self.running = running
+        self.times_out = times_out
+        self.wait_error = wait_error
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return None if self.running else 0
+
+    def terminate(self):
+        self.terminated = True
+
+    def wait(self, timeout=None):
+        if self.wait_error is not None and not self.killed:
+            raise self.wait_error
+        if self.times_out and not self.killed:
+            raise subprocess.TimeoutExpired(str(self.pid), timeout)
+        self.running = False
+        return 0
+
+    def kill(self):
+        self.killed = True
+
+
+def test_legacy_tageditor_is_disabled_by_default():
+    args = gui.parser.parse_args([])
+
+    assert args.enable_legacy_tageditor is False
+
+
+def test_helper_launchers_return_process_handles():
+    process = FakeProcess(100)
+    args = gui.parser.parse_args([])
+
+    with mock.patch.object(gui, "args", args, create=True), mock.patch.object(
+        gui.subprocess, "Popen", return_value=process
+    ):
+        assert gui.run_tensorboard() is process
+        assert gui.run_train_monitor() is process
+
+
+def test_linux_helper_processes_request_parent_death_signal():
+    process = FakeProcess(107)
+
+    with mock.patch.object(gui.sys, "platform", "linux"), \
+            mock.patch.object(gui.os, "getpid", return_value=42), \
+            mock.patch.object(gui.subprocess, "Popen", return_value=process) as popen:
+        assert gui._popen(["helper"]) is process
+
+    assert popen.call_args.args[0] == [
+        gui.sys.executable,
+        str(gui.base_dir_path() / "mikazuki" / "child_process.py"),
+        "42",
+        "helper",
+    ]
+    assert "preexec_fn" not in popen.call_args.kwargs
+
+
+def test_non_linux_helper_processes_do_not_use_preexec():
+    process = FakeProcess(108)
+
+    with mock.patch.object(gui.sys, "platform", "win32"), \
+            mock.patch.object(gui.subprocess, "Popen", return_value=process) as popen:
+        assert gui._popen(["helper"]) is process
+
+    assert "preexec_fn" not in popen.call_args.kwargs
+
+
+def test_linux_child_exits_when_parent_is_killed_from_another_directory(tmp_path):
+    if not sys.platform.startswith("linux"):
+        return
+
+    root = Path(__file__).resolve().parents[1]
+    parent = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import os,signal,sys,time; from gui import _popen; "
+                "signal.pthread_sigmask(signal.SIG_BLOCK,{signal.SIGTERM}); "
+                "child=_popen([sys.executable,'-c','import time; time.sleep(60)']); "
+                "print(child.pid, flush=True); time.sleep(0.2); os._exit(0)"
+            ),
+        ],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONPATH": str(root)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    child_pid = int(parent.stdout.strip())
+    deadline = time.monotonic() + 3
+    while Path(f"/proc/{child_pid}").exists() and time.monotonic() < deadline:
+        time.sleep(0.05)
+
+    assert not Path(f"/proc/{child_pid}").exists()
+
+
+def test_main_environment_does_not_require_gradio():
+    root = Path(__file__).resolve().parents[1]
+    requirements = (root / "requirements.txt").read_text(encoding="utf-8-sig")
+    setup = (root / "setup_environment.py").read_text(encoding="utf-8")
+    constraints = (root / "config/anima_fast_environment/main-constraints-cu130.txt").read_text(encoding="utf-8")
+
+    assert not any(line.strip().startswith("gradio") for line in requirements.splitlines())
+    assert '"diffusers", "gradio"' not in setup
+    assert not any(line.strip().startswith("gradio") for line in constraints.splitlines())
+
+
+def test_main_environment_declares_websockets_directly():
+    root = Path(__file__).resolve().parents[1]
+    requirements = (root / "requirements.txt").read_text(encoding="utf-8-sig")
+
+    assert any(line.strip().startswith("websockets==") for line in requirements.splitlines())
+
+
+def test_stop_child_processes_terminates_running_children():
+    tensorboard = FakeProcess(101)
+    monitor = FakeProcess(102)
+    exited = FakeProcess(103, running=False)
+
+    gui.stop_child_processes([
+        ("TensorBoard", tensorboard),
+        ("train monitor", monitor),
+        ("exited", exited),
+    ])
+
+    assert tensorboard.terminated is True
+    assert monitor.terminated is True
+    assert exited.terminated is False
+    assert tensorboard.killed is False
+    assert monitor.killed is False
+
+
+def test_stop_child_processes_kills_child_after_timeout():
+    stuck = FakeProcess(104, times_out=True)
+
+    gui.stop_child_processes([("TensorBoard", stuck)], timeout=0)
+
+    assert stuck.terminated is True
+    assert stuck.killed is True
+    assert stuck.running is False
+
+
+def test_stop_child_processes_kills_child_after_wait_error():
+    stuck = FakeProcess(106, wait_error=OSError("wait failed"))
+
+    gui.stop_child_processes([("TensorBoard", stuck)])
+
+    assert stuck.killed is True
+    assert stuck.running is False
+
+
+def test_launch_cleans_up_helpers_when_server_fails():
+    process = FakeProcess(105)
+    args = gui.parser.parse_args([
+        "--skip-prepare-environment",
+        "--disable-train-monitor",
+    ])
+    uvicorn = types.SimpleNamespace(run=mock.Mock(side_effect=RuntimeError("server failed")))
+
+    with mock.patch.object(gui, "args", args, create=True), \
+            mock.patch.object(gui, "sanitize_embedded_deps"), \
+            mock.patch.object(gui, "train_env_overrides", return_value={}), \
+            mock.patch.object(gui, "ensure_requirements_installed"), \
+            mock.patch.object(gui, "ensure_port_available", side_effect=lambda port, *_args, **_kwargs: port), \
+            mock.patch.object(gui, "run_tensorboard", return_value=process), \
+            mock.patch("mikazuki.china_hub.enable_china_hub", return_value=False), \
+            mock.patch("mikazuki.update_check.local_version", return_value="test"), \
+            mock.patch.dict(sys.modules, {"uvicorn": uvicorn}):
+        try:
+            gui.launch()
+        except RuntimeError as error:
+            assert str(error) == "server failed"
+        else:
+            raise AssertionError("launch should propagate the server failure")
+
+    assert process.terminated is True
+    assert process.running is False


### PR DESCRIPTION
Manage auxiliary services through the GUI lifecycle and make the legacy Gradio editor opt-in so repeated starts do not leak processes or dependencies. Refs #313.

改动清单
- 修复 TensorBoard、train monitor 子进程泄漏。
- 正常退出时执行 terminate → wait → kill。
- Linux 下主进程被 SIGKILL 时，通过 PDEATHSIG 回收子进程。
- 旧 Gradio tag editor 改为显式 opt-in。
- 从主环境移除 Gradio 依赖和检查。
- 显式添加 websockets==11.0.3。
- requirements 读取统一兼容 UTF-8 BOM。
- 新增生命周期、异常退出、跨目录及信号竞态测试。
- 验证：633 passed, 10 skipped。