### PR TITLE
fix(networks): dtype-align lycoris LoKr bypass forward via runtime pa…

### DIFF
--- a/mikazuki/lycoris_patches.py
+++ b/mikazuki/lycoris_patches.py
@@ -2,8 +2,8 @@
 
 ``lycoris.kohya`` is a pip dependency (not vendored) and its upstream is
 unmaintained, so bugs cannot be fixed at the source. The training subprocess
-entry (``mikazuki/accelerate_launch.py``) applies these patches before the
-trainer script imports lycoris.
+applies these patches from ``vendor/sd-scripts/train_network.py`` right
+before importing the network module.
 
 Currently patched:
 
@@ -15,15 +15,34 @@ Currently patched:
   the bypass path align the weights to the incoming activation dtype, which
   is a no-op when dtypes already match. Casts keep autograd connectivity, so
   fp32 master weights for optimizers like Automagic are untouched.
+
+The patched body mirrors lycoris-lora **3.3.0** (verified byte-identical in
+3.2.0.post2) with two additional upstream conv-bypass fixes: the batch-size
+variable shadowing the ``b`` weight, and the Tucker closing 1x1 conv getting
+``w2_a`` in its stored ``(dim, vp)`` orientation instead of the required
+``(vp, dim)``. Application is gated on the verified versions because the
+copied body is version-specific; unknown versions are skipped with a warning
+(same policy as ``mikazuki/anima_backend/lycoris_patch.py``).
 """
 
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 
 logger = logging.getLogger(__name__)
 
 _PATCH_MARK = "_mikazuki_dtype_aligned"
+
+# bypass_forward_diff bodies verified identical across these releases.
+_SUPPORTED_LYCORIS_VERSIONS = {"3.3.0", "3.2.0.post2"}
+
+
+def _lycoris_lora_version() -> str | None:
+    try:
+        return importlib.metadata.version("lycoris-lora")
+    except importlib.metadata.PackageNotFoundError:
+        return None
 
 
 def _make_patched_bypass_forward_diff():
@@ -31,8 +50,8 @@ def _make_patched_bypass_forward_diff():
     import torch.nn.functional as F
 
     def bypass_forward_diff(self, h, scale=1):
-        # Body mirrors lycoris_lora 3.2.0.post2 lycoris/modules/lokr.py, with
-        # every weight tensor aligned to the activation dtype before use.
+        # Body mirrors lycoris-lora 3.3.0 lycoris/modules/lokr.py, with every
+        # weight tensor aligned to the activation dtype before use.
         dtype = h.dtype
         is_conv = self.module_type.startswith("conv")
         if self.use_w2:
@@ -43,8 +62,12 @@ def _make_patched_bypass_forward_diff():
 
             if self.tucker:
                 t = self.lokr_t2.to(dtype)
+                # Upstream bugs fixed here: ``b`` was later shadowed by the
+                # batch size, and w2_a is stored (dim, vp) while the closing
+                # 1x1 conv needs (vp, dim) - see rebuild_tucker's einsum.
+                b = b.mT
                 a = a.view(*a.shape, *[1] * (len(t.shape) - 2))
-                b = b.view(*b.shape, *[1] * (len(t.shape) - 2))
+                b = b.reshape(*b.shape, *[1] * (len(t.shape) - 2))
             elif is_conv:
                 a = a.view(*a.shape, *self.shape[2:])
                 b = b.view(*b.shape, *[1] * (len(self.shape) - 2))
@@ -57,9 +80,6 @@ def _make_patched_bypass_forward_diff():
 
         if is_conv:
             # (b, uq), vq, ...
-            # NOTE: upstream rebinds ``b`` here (``b, _, *rest = h.shape``),
-            # shadowing the w2_a weight and making conv bypass crash; we use a
-            # distinct name so the weight stays reachable below.
             bsz, _, *rest = h.shape
             h_in_group = h.reshape(bsz * uq, -1, *rest)
         else:
@@ -108,17 +128,28 @@ def _make_patched_bypass_forward_diff():
 
         return self.drop(h * scale * self.scalar)
 
-    bypass_forward_diff._mikazuki_dtype_aligned_src = "lycoris_lora-3.2.0.post2"  # type: ignore[attr-defined]
+    bypass_forward_diff._mikazuki_dtype_aligned_src = "lycoris-lora-3.3.0"  # type: ignore[attr-defined]
     return bypass_forward_diff
 
 
 def apply_lycoris_patches() -> None:
-    """Best-effort, defensive: never blocks training when lycoris is absent
-    or its layout drifts from the known version."""
+    """Best-effort, defensive: never blocks training when lycoris is absent,
+    its layout drifts from the known version, or the release is unverified."""
+    version = _lycoris_lora_version()
+    if version is None:
+        return  # lycoris not installed; nothing to patch
+    if version not in _SUPPORTED_LYCORIS_VERSIONS:
+        logger.warning(
+            "lycoris-lora %s is not a verified version for the LoKr bypass dtype "
+            "patch (verified: %s); skipping. LoKr bypass_mode may crash on dtype "
+            "mismatch (issue #323)",
+            version,
+            ", ".join(sorted(_SUPPORTED_LYCORIS_VERSIONS)),
+        )
+        return
+
     try:
         from lycoris.modules import lokr as lycoris_lokr
-    except ImportError:
-        return
     except Exception:  # noqa: BLE001 - a broken lycoris install must not kill launch
         logger.warning("lycoris import failed unexpectedly; skipping lycoris patches", exc_info=True)
         return

--- a/mikazuki/lycoris_patches.py
+++ b/mikazuki/lycoris_patches.py
@@ -1,0 +1,140 @@
+"""Runtime patches for the third-party ``lycoris`` package (issue #323).
+
+``lycoris.kohya`` is a pip dependency (not vendored) and its upstream is
+unmaintained, so bugs cannot be fixed at the source. The training subprocess
+entry (``mikazuki/accelerate_launch.py``) applies these patches before the
+trainer script imports lycoris.
+
+Currently patched:
+
+- ``LokrModule.bypass_forward_diff``: the bypass forward path feeds the raw
+  fp32 LoKr parameters into ``F.linear``/``F.conv*`` against activations that
+  may be bf16/fp16 (e.g. Anima sampling with bf16 autocast or native bf16
+  weights), raising ``expected mat1 and mat2 to have the same dtype``. The
+  non-bypass forward already aligns via ``.to(self.dtype)``; this patch makes
+  the bypass path align the weights to the incoming activation dtype, which
+  is a no-op when dtypes already match. Casts keep autograd connectivity, so
+  fp32 master weights for optimizers like Automagic are untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PATCH_MARK = "_mikazuki_dtype_aligned"
+
+
+def _make_patched_bypass_forward_diff():
+    import torch
+    import torch.nn.functional as F
+
+    def bypass_forward_diff(self, h, scale=1):
+        # Body mirrors lycoris_lora 3.2.0.post2 lycoris/modules/lokr.py, with
+        # every weight tensor aligned to the activation dtype before use.
+        dtype = h.dtype
+        is_conv = self.module_type.startswith("conv")
+        if self.use_w2:
+            ba = self.lokr_w2.to(dtype)
+        else:
+            a = self.lokr_w2_b.to(dtype)
+            b = self.lokr_w2_a.to(dtype)
+
+            if self.tucker:
+                t = self.lokr_t2.to(dtype)
+                a = a.view(*a.shape, *[1] * (len(t.shape) - 2))
+                b = b.view(*b.shape, *[1] * (len(t.shape) - 2))
+            elif is_conv:
+                a = a.view(*a.shape, *self.shape[2:])
+                b = b.view(*b.shape, *[1] * (len(self.shape) - 2))
+
+        if self.use_w1:
+            c = self.lokr_w1.to(dtype)
+        else:
+            c = (self.lokr_w1_a @ self.lokr_w1_b).to(dtype)
+        uq = c.size(1)
+
+        if is_conv:
+            # (b, uq), vq, ...
+            # NOTE: upstream rebinds ``b`` here (``b, _, *rest = h.shape``),
+            # shadowing the w2_a weight and making conv bypass crash; we use a
+            # distinct name so the weight stays reachable below.
+            bsz, _, *rest = h.shape
+            h_in_group = h.reshape(bsz * uq, -1, *rest)
+        else:
+            # b, ..., uq, vq
+            h_in_group = h.reshape(*h.shape[:-1], uq, -1)
+
+        if self.use_w2:
+            hb = self.op(h_in_group, ba, **self.kw_dict)
+        else:
+            if is_conv:
+                if self.tucker:
+                    ha = self.op(h_in_group, a)
+                    ht = self.op(ha, t, **self.kw_dict)
+                    hb = self.op(ht, b)
+                else:
+                    ha = self.op(h_in_group, a, **self.kw_dict)
+                    hb = self.op(ha, b)
+            else:
+                ha = self.op(h_in_group, a, **self.kw_dict)
+                hb = self.op(ha, b)
+
+        if is_conv:
+            # (b, uq), vp, ..., f
+            # -> b, uq, vp, ..., f
+            # -> b, f, vp, ..., uq
+            hb = hb.view(bsz, -1, *hb.shape[1:])
+            h_cross_group = hb.transpose(1, -1)
+        else:
+            # b, ..., uq, vq
+            # -> b, ..., vq, uq
+            h_cross_group = hb.transpose(-1, -2)
+
+        hc = F.linear(h_cross_group, c)
+        if is_conv:
+            # b, f, vp, ..., up
+            # -> b, up, vp, ... ,f
+            # -> b, c, ..., f
+            hc = hc.transpose(1, -1)
+            h = hc.reshape(bsz, -1, *hc.shape[3:])
+        else:
+            # b, ..., vp, up
+            # -> b, ..., up, vp
+            # -> b, ..., c
+            hc = hc.transpose(-1, -2)
+            h = hc.reshape(*hc.shape[:-2], -1)
+
+        return self.drop(h * scale * self.scalar)
+
+    bypass_forward_diff._mikazuki_dtype_aligned_src = "lycoris_lora-3.2.0.post2"  # type: ignore[attr-defined]
+    return bypass_forward_diff
+
+
+def apply_lycoris_patches() -> None:
+    """Best-effort, defensive: never blocks training when lycoris is absent
+    or its layout drifts from the known version."""
+    try:
+        from lycoris.modules import lokr as lycoris_lokr
+    except ImportError:
+        return
+    except Exception:  # noqa: BLE001 - a broken lycoris install must not kill launch
+        logger.warning("lycoris import failed unexpectedly; skipping lycoris patches", exc_info=True)
+        return
+
+    module_cls = getattr(lycoris_lokr, "LokrModule", None)
+    original = getattr(module_cls, "bypass_forward_diff", None) if module_cls is not None else None
+    if module_cls is None or original is None:
+        logger.warning(
+            "lycoris LokrModule layout not recognized (version drift?); "
+            "skipping bypass dtype patch for issue #323"
+        )
+        return
+    if getattr(original, _PATCH_MARK, False):
+        return
+
+    patched = _make_patched_bypass_forward_diff()
+    setattr(patched, _PATCH_MARK, True)
+    module_cls.bypass_forward_diff = patched
+    logger.info("Applied lycoris LokrModule bypass dtype-alignment patch (issue #323)")

--- a/tests/test_lycoris_patches.py
+++ b/tests/test_lycoris_patches.py
@@ -49,8 +49,8 @@ def _install_fake_lycoris(*, with_lokr_module: bool = True) -> types.ModuleType:
 
 class ApplyPatchesDefensivenessTests(unittest.TestCase):
     def test_noop_when_lycoris_not_installed(self):
-        with mock.patch.dict(sys.modules, {"lycoris": None, "lycoris.modules": None, "lycoris.modules.lokr": None}):
-            lycoris_patches.apply_lycoris_patches()  # must not raise
+        # test venv has no lycoris-lora dist metadata -> version None -> skip
+        lycoris_patches.apply_lycoris_patches()  # must not raise
 
     def test_patches_lokr_module_and_is_idempotent(self):
         patcher, lokr_mod = _install_fake_lycoris()
@@ -58,19 +58,34 @@ class ApplyPatchesDefensivenessTests(unittest.TestCase):
             cls = lokr_mod.LokrModule
             original = cls.bypass_forward_diff
 
-            lycoris_patches.apply_lycoris_patches()
-            self.assertIsNot(cls.bypass_forward_diff, original)
-            self.assertTrue(getattr(cls.bypass_forward_diff, lycoris_patches._PATCH_MARK, False))
+            with mock.patch.object(lycoris_patches, "_lycoris_lora_version", return_value="3.3.0"):
+                lycoris_patches.apply_lycoris_patches()
+                self.assertIsNot(cls.bypass_forward_diff, original)
+                self.assertTrue(getattr(cls.bypass_forward_diff, lycoris_patches._PATCH_MARK, False))
 
-            patched_once = cls.bypass_forward_diff
-            lycoris_patches.apply_lycoris_patches()
-            self.assertIs(cls.bypass_forward_diff, patched_once)
+                patched_once = cls.bypass_forward_diff
+                lycoris_patches.apply_lycoris_patches()
+                self.assertIs(cls.bypass_forward_diff, patched_once)
+
+    def test_skips_with_warning_on_unverified_version(self):
+        patcher, lokr_mod = _install_fake_lycoris()
+        with patcher:
+            cls = lokr_mod.LokrModule
+            original = cls.bypass_forward_diff
+
+            with mock.patch.object(lycoris_patches, "_lycoris_lora_version", return_value="9.9.9"):
+                with self.assertLogs(lycoris_patches.logger, level="WARNING") as cm:
+                    lycoris_patches.apply_lycoris_patches()
+
+            self.assertIs(cls.bypass_forward_diff, original)
+            self.assertIn("9.9.9", "\n".join(cm.output))
 
     def test_skips_with_warning_on_unrecognized_layout(self):
         patcher, lokr_mod = _install_fake_lycoris(with_lokr_module=False)
         with patcher:
-            with self.assertLogs(lycoris_patches.logger, level="WARNING"):
-                lycoris_patches.apply_lycoris_patches()
+            with mock.patch.object(lycoris_patches, "_lycoris_lora_version", return_value="3.3.0"):
+                with self.assertLogs(lycoris_patches.logger, level="WARNING"):
+                    lycoris_patches.apply_lycoris_patches()
             self.assertFalse(hasattr(lokr_mod, "LokrModule"))
 
     def test_never_raises_on_broken_lycoris(self):
@@ -85,7 +100,8 @@ class ApplyPatchesDefensivenessTests(unittest.TestCase):
             "lycoris.modules": broken,
         }
         with mock.patch.dict(sys.modules, fake):
-            lycoris_patches.apply_lycoris_patches()  # must not raise
+            with mock.patch.object(lycoris_patches, "_lycoris_lora_version", return_value="3.3.0"):
+                lycoris_patches.apply_lycoris_patches()  # must not raise
 
 
 class _FakeLokrModule:
@@ -150,6 +166,69 @@ class PatchedBypassForwardDiffTests(unittest.TestCase):
         for p in (module.lokr_w1_a, module.lokr_w1_b, module.lokr_w2_a, module.lokr_w2_b):
             self.assertIsNotNone(p.grad)
             self.assertEqual(p.dtype, torch.float32)
+
+
+class _FakeTuckerConvLokrModule:
+    """Minimal mimic of lycoris LokrModule, conv + tucker branch.
+
+    3.3.0 shapes: w2_b (dim, vq), t2 (dim, dim, *k), w2_a (dim, vp);
+    in_ch = uq * vq, out_ch = out_l * vp.
+    """
+
+    def __init__(self, dtype=torch.float32):
+        self.module_type = "conv2d"
+        self.use_w1 = False
+        self.use_w2 = False
+        self.tucker = True
+        self.kw_dict = {}
+        self.scalar = 1.0
+        self.drop = lambda x: x
+        self.op = F.conv2d
+        self.shape = ((2, 5), (2, 3), 1, 1)  # ((out_l, vp), (uq, vq), k1, k2)
+        uq, vq, dim, vp, out_l, r = 2, 3, 4, 5, 2, 3
+        self.lokr_w2_b = torch.nn.Parameter(torch.randn(dim, vq, dtype=dtype) * 0.02)
+        self.lokr_t2 = torch.nn.Parameter(torch.randn(dim, dim, 1, 1, dtype=dtype) * 0.02)
+        self.lokr_w2_a = torch.nn.Parameter(torch.randn(dim, vp, dtype=dtype) * 0.02)
+        self.lokr_w1_a = torch.nn.Parameter(torch.randn(out_l, r, dtype=dtype) * 0.02)
+        self.lokr_w1_b = torch.nn.Parameter(torch.randn(r, uq, dtype=dtype) * 0.02)
+
+
+class PatchedTuckerConvTests(unittest.TestCase):
+    """Regression for the two stacked upstream conv-bypass bugs: the `b`
+    shadowing and the (dim, vp) vs (vp, dim) orientation of w2_a."""
+
+    patched = staticmethod(lycoris_patches._make_patched_bypass_forward_diff())
+
+    def test_tucker_conv_runs_and_matches_reference(self):
+        module = _FakeTuckerConvLokrModule()
+        h = torch.randn(2, 6, 3, 3)  # (batch, uq*vq, H, W)
+
+        out = self.patched(module, h)
+        self.assertEqual(out.shape, (2, 10, 3, 3))  # out_l * vp channels
+
+        # reference: same contraction with explicitly correct orientation
+        a = module.lokr_w2_b.view(4, 3, 1, 1)
+        b = module.lokr_w2_a.mT.reshape(5, 4, 1, 1)
+        c = module.lokr_w1_a @ module.lokr_w1_b
+        h_in_group = h.reshape(2 * 2, 3, 3, 3)
+        ha = F.conv2d(h_in_group, a)
+        ht = F.conv2d(ha, module.lokr_t2)
+        hb = F.conv2d(ht, b)
+        hb = hb.view(2, -1, *hb.shape[1:])
+        h_cross_group = hb.transpose(1, -1)
+        hc = F.linear(h_cross_group, c)
+        ref = hc.transpose(1, -1).reshape(2, -1, 3, 3)
+
+        self.assertTrue(torch.allclose(out, ref, atol=1e-5))
+
+    def test_tucker_conv_bf16_activation_fp32_weights(self):
+        module = _FakeTuckerConvLokrModule()
+        h = torch.randn(2, 6, 3, 3, dtype=torch.bfloat16)
+
+        out = self.patched(module, h)
+
+        self.assertEqual(out.dtype, torch.bfloat16)
+        self.assertTrue(torch.isfinite(out.float()).all())
 
 
 if __name__ == "__main__":

--- a/tests/test_lycoris_patches.py
+++ b/tests/test_lycoris_patches.py
@@ -1,0 +1,156 @@
+"""Tests for mikazuki.lycoris_patches (issue #323).
+
+Covers:
+- defensive application (missing lycoris / unknown layout / idempotency)
+- the patched LokrModule.bypass_forward_diff aligning fp32 weights to bf16
+  activations, staying a no-op when dtypes already match, and keeping
+  autograd connectivity to the fp32 master weights
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+import torch
+import torch.nn.functional as F
+
+from mikazuki import lycoris_patches
+
+
+def _install_fake_lycoris(*, with_lokr_module: bool = True) -> types.ModuleType:
+    lycoris_pkg = types.ModuleType("lycoris")
+    lycoris_pkg.__path__ = []
+    modules_pkg = types.ModuleType("lycoris.modules")
+    modules_pkg.__path__ = []
+    lokr_mod = types.ModuleType("lycoris.modules.lokr")
+
+    if with_lokr_module:
+
+        class LokrModule:
+            def bypass_forward_diff(self, h, scale=1):
+                raise RuntimeError(
+                    "expected mat1 and mat2 to have the same dtype, but got: c10::BFloat16 != float"
+                )
+
+        lokr_mod.LokrModule = LokrModule
+
+    modules_pkg.lokr = lokr_mod
+    lycoris_pkg.modules = modules_pkg
+    fake = {
+        "lycoris": lycoris_pkg,
+        "lycoris.modules": modules_pkg,
+        "lycoris.modules.lokr": lokr_mod,
+    }
+    return mock.patch.dict(sys.modules, fake), lokr_mod
+
+
+class ApplyPatchesDefensivenessTests(unittest.TestCase):
+    def test_noop_when_lycoris_not_installed(self):
+        with mock.patch.dict(sys.modules, {"lycoris": None, "lycoris.modules": None, "lycoris.modules.lokr": None}):
+            lycoris_patches.apply_lycoris_patches()  # must not raise
+
+    def test_patches_lokr_module_and_is_idempotent(self):
+        patcher, lokr_mod = _install_fake_lycoris()
+        with patcher:
+            cls = lokr_mod.LokrModule
+            original = cls.bypass_forward_diff
+
+            lycoris_patches.apply_lycoris_patches()
+            self.assertIsNot(cls.bypass_forward_diff, original)
+            self.assertTrue(getattr(cls.bypass_forward_diff, lycoris_patches._PATCH_MARK, False))
+
+            patched_once = cls.bypass_forward_diff
+            lycoris_patches.apply_lycoris_patches()
+            self.assertIs(cls.bypass_forward_diff, patched_once)
+
+    def test_skips_with_warning_on_unrecognized_layout(self):
+        patcher, lokr_mod = _install_fake_lycoris(with_lokr_module=False)
+        with patcher:
+            with self.assertLogs(lycoris_patches.logger, level="WARNING"):
+                lycoris_patches.apply_lycoris_patches()
+            self.assertFalse(hasattr(lokr_mod, "LokrModule"))
+
+    def test_never_raises_on_broken_lycoris(self):
+        broken = types.ModuleType("lycoris.modules")
+
+        def _boom(name):
+            raise RuntimeError("corrupt install")
+
+        broken.__getattr__ = _boom
+        fake = {
+            "lycoris": types.ModuleType("lycoris"),
+            "lycoris.modules": broken,
+        }
+        with mock.patch.dict(sys.modules, fake):
+            lycoris_patches.apply_lycoris_patches()  # must not raise
+
+
+class _FakeLokrModule:
+    """Minimal mimic of lycoris LokrModule (linear, decomposed w1/w2)."""
+
+    def __init__(self, dtype=torch.float32):
+        # in_dim = in_m * in_n = 2 * 3 = 6, out_dim = out_l * out_k = 2 * 5 = 10
+        self.module_type = "linear"
+        self.use_w1 = False
+        self.use_w2 = False
+        self.tucker = False
+        self.kw_dict = {}
+        self.scalar = 1.0
+        self.drop = lambda x: x
+        self.op = F.linear
+        self.lokr_w1_a = torch.nn.Parameter(torch.randn(2, 4, dtype=dtype) * 0.02)
+        self.lokr_w1_b = torch.nn.Parameter(torch.randn(4, 2, dtype=dtype) * 0.02)
+        self.lokr_w2_a = torch.nn.Parameter(torch.randn(5, 4, dtype=dtype) * 0.02)
+        self.lokr_w2_b = torch.nn.Parameter(torch.randn(4, 3, dtype=dtype) * 0.02)
+
+
+class PatchedBypassForwardDiffTests(unittest.TestCase):
+    patched = staticmethod(lycoris_patches._make_patched_bypass_forward_diff())
+
+    def test_bf16_activation_against_fp32_weights_no_longer_crashes(self):
+        module = _FakeLokrModule()
+        h = torch.randn(2, 6, dtype=torch.bfloat16)
+
+        with self.assertRaises(RuntimeError):
+            # unpatched behavior: raw fp32 weights vs bf16 activation
+            a = module.lokr_w2_b
+            F.linear(h.reshape(2, 2, 3), a)
+
+        out = self.patched(module, h)
+        self.assertEqual(out.dtype, torch.bfloat16)
+        self.assertEqual(out.shape, (2, 10))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_fp32_activation_matches_unpatched_reference(self):
+        module = _FakeLokrModule()
+        h = torch.randn(2, 6, dtype=torch.float32)
+
+        out = self.patched(module, h)
+
+        c = module.lokr_w1_a @ module.lokr_w1_b
+        h_in_group = h.reshape(2, 2, 3)
+        ha = F.linear(h_in_group, module.lokr_w2_b)
+        hb = F.linear(ha, module.lokr_w2_a)
+        h_cross_group = hb.transpose(-1, -2)
+        hc = F.linear(h_cross_group, c)
+        ref = hc.transpose(-1, -2).reshape(2, -1)
+
+        self.assertTrue(torch.allclose(out, ref, atol=1e-6))
+
+    def test_gradients_flow_to_fp32_master_weights(self):
+        module = _FakeLokrModule()
+        h = torch.randn(2, 6, dtype=torch.bfloat16)
+
+        out = self.patched(module, h)
+        out.float().sum().backward()
+
+        for p in (module.lokr_w1_a, module.lokr_w1_b, module.lokr_w2_a, module.lokr_w2_b):
+            self.assertIsNotNone(p.grad)
+            self.assertEqual(p.dtype, torch.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/sd-scripts/train_network.py
+++ b/vendor/sd-scripts/train_network.py
@@ -639,6 +639,15 @@ class NetworkTrainer:
         # 差分追加学習のためにモデルを読み込む
         sys.path.append(os.path.dirname(__file__))
         accelerator.print("import network module:", args.network_module)
+        if "lycoris" in str(args.network_module).lower():
+            try:
+                # mikazuki: align third-party lycoris bypass dtypes (issue #323).
+                # Guarded so standalone sd-scripts usage without mikazuki still works.
+                from mikazuki.lycoris_patches import apply_lycoris_patches
+
+                apply_lycoris_patches()
+            except Exception:
+                pass
         network_module = importlib.import_module(args.network_module)
 
         if args.base_weights is not None:


### PR DESCRIPTION
…tch (#323)

LoKr bypass_mode feeds raw fp32 weights into F.linear against bf16 activations, crashing sampling with 'BFloat16 != float' whenever the Automagic/CAME guardrail (pop full_fp16, flip mixed fp16 to bf16) splits weight and activation dtypes. lycoris is an unmaintained pip dependency, so patch LokrModule.bypass_forward_diff at runtime from the shared kohya trainer entry (train_network.py), aligning weights to the activation dtype - a no-op when dtypes already match and autograd-transparent to fp32 master weights. Also fixes an upstream conv-branch variable shadow that made conv bypass unusable.