### PR TITLE
fix(anima): actually merge LyCORIS weights in anima_minimal_inference…

### DIFF
--- a/tests/test_anima_minimal_inference.py
+++ b/tests/test_anima_minimal_inference.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+import torch
+
+
+VENDOR_DIR = Path(__file__).resolve().parents[1] / "vendor" / "sd-scripts"
+sys.path.insert(0, str(VENDOR_DIR))
+import anima_minimal_inference as inference  # noqa: E402
+
+
+class _FakeModel:
+    def to(self, *args, **kwargs):
+        return self
+
+    def eval(self):
+        return self
+
+    def requires_grad_(self, value):
+        return self
+
+
+class _FakeNetwork:
+    def __init__(self, merges):
+        self._merges = merges
+
+    def merge_to(self, text_encoder, unet, weights_sd, dtype, device):
+        self._merges.append((weights_sd, dtype, device))
+
+
+def _args(*, lycoris, lora_weight=None, lora_multiplier=1.0):
+    return SimpleNamespace(
+        lycoris=lycoris,
+        lora_weight=lora_weight,
+        lora_multiplier=lora_multiplier,
+        fp8_scaled=False,
+        dit="dit.safetensors",
+        attn_mode="torch",
+    )
+
+
+class AnimaMinimalInferenceTests(TestCase):
+    def test_lycoris_merges_each_weight_once_and_fills_missing_multipliers(self):
+        weights = {"one.safetensors": {"one": torch.tensor(1)}, "two.safetensors": {"two": torch.tensor(2)}}
+        loaded = []
+        network_calls = []
+        merges = []
+        model = _FakeModel()
+
+        def fake_load_file(path):
+            loaded.append(path)
+            return weights[path]
+
+        def fake_create_network(**kwargs):
+            network_calls.append(kwargs)
+            return _FakeNetwork(merges), None
+
+        with (
+            mock.patch.object(inference, "load_file", side_effect=fake_load_file),
+            mock.patch.object(inference, "create_network_from_weights", side_effect=fake_create_network),
+            mock.patch.object(inference.anima_utils, "load_anima_model", return_value=model),
+            mock.patch.object(inference, "clean_memory_on_device"),
+        ):
+            result = inference.load_dit_model(
+                _args(
+                    lycoris=True,
+                    lora_weight=list(weights),
+                    lora_multiplier=[0.5],
+                ),
+                torch.device("cpu"),
+            )
+
+        self.assertIs(result, model)
+        self.assertEqual(loaded, list(weights))
+        self.assertEqual([call["multiplier"] for call in network_calls], [0.5, 1.0])
+        self.assertEqual([call["file"] for call in network_calls], [None, None])
+        self.assertEqual([call["weights_sd"] for call in network_calls], list(weights.values()))
+        self.assertEqual([merge[0] for merge in merges], list(weights.values()))
+
+    def test_non_lycoris_path_still_passes_loaded_weights_to_model_loader(self):
+        loaded = {"one": {"lora_unet_one": torch.tensor(1)}}
+        model = _FakeModel()
+
+        with (
+            mock.patch.object(inference, "load_file", return_value=loaded["one"]),
+            mock.patch.object(inference.anima_utils, "load_anima_model", return_value=model) as load_model,
+            mock.patch.object(inference, "clean_memory_on_device"),
+        ):
+            inference.load_dit_model(_args(lycoris=False, lora_weight=["one"]), torch.device("cpu"))
+
+        self.assertEqual(load_model.call_args.kwargs["lora_weights_list"], [loaded["one"]])

--- a/vendor/sd-scripts/anima_minimal_inference.py
+++ b/vendor/sd-scripts/anima_minimal_inference.py
@@ -264,6 +264,20 @@ def load_dit_model(
         lora_weights_list=lora_weights_list,
         lora_multipliers=args.lora_multiplier,
     )
+
+    # LyCORIS: merge adapter weights into the freshly loaded DiT (loading_device is CPU)
+    if args.lycoris and args.lora_weight is not None and len(args.lora_weight) > 0:
+        lycoris_multipliers = list(args.lora_multiplier) if isinstance(args.lora_multiplier, list) else [args.lora_multiplier]
+        while len(lycoris_multipliers) < len(args.lora_weight):
+            lycoris_multipliers.append(1.0)
+        for lora_weight, multiplier in zip(args.lora_weight, lycoris_multipliers):
+            logger.info(f"Merging LyCORIS weight from: {lora_weight} (multiplier={multiplier})")
+            weights_sd = load_file(lora_weight)
+            network, _ = create_network_from_weights(multiplier, lora_weight, None, None, model, for_inference=True)
+            network.merge_to(None, model, weights_sd, torch.bfloat16, device)
+        del network, weights_sd
+        clean_memory_on_device(device)
+
     if not args.fp8_scaled:
         # simple cast to dit_weight_dtype
         target_dtype = None  # load as-is (dit_weight_dtype == dtype of the weights in state_dict)

--- a/vendor/sd-scripts/anima_minimal_inference.py
+++ b/vendor/sd-scripts/anima_minimal_inference.py
@@ -273,7 +273,15 @@ def load_dit_model(
         for lora_weight, multiplier in zip(args.lora_weight, lycoris_multipliers):
             logger.info(f"Merging LyCORIS weight from: {lora_weight} (multiplier={multiplier})")
             weights_sd = load_file(lora_weight)
-            network, _ = create_network_from_weights(multiplier, lora_weight, None, None, model, for_inference=True)
+            network, _ = create_network_from_weights(
+                multiplier=multiplier,
+                file=None,
+                vae=None,
+                text_encoder=None,
+                unet=model,
+                weights_sd=weights_sd,
+                for_inference=True,
+            )
             network.merge_to(None, model, weights_sd, torch.bfloat16, device)
         del network, weights_sd
         clean_memory_on_device(device)


### PR DESCRIPTION
#329 

The --lycoris branch loaded the DiT with lora_weights_list=None and never called create_network_from_weights, so LoKr/LoHa adapters were silently dropped and outputs were pixel-identical to the base model. Merge the adapter into the freshly CPU-loaded DiT right after load_anima_model.