### PR TITLE
fix(anima-fast): align preflight cache identity with v1.17.1 relative…

### DIFF
--- a/mikazuki/anima_fast_backend/preflight.py
+++ b/mikazuki/anima_fast_backend/preflight.py
@@ -333,53 +333,46 @@ def _validate_plugin_python(runtime: RuntimeConfig, errors: list[str]) -> None:
             )
 
 
-def _v117_latent_cache_stems(root: Path | None) -> set[str]:
-    if root is None or not root.is_dir():
-        return set()
+def _image_pixel_size(path: Path) -> tuple[int, int] | None:
+    try:
+        import imagesize
+
+        width, height = imagesize.get(path)
+        if width > 0 and height > 0:
+            return int(width), int(height)
+    except Exception:
+        pass
+    try:
+        from PIL import Image
+
+        with Image.open(path) as image:
+            return int(image.width), int(image.height)
+    except Exception:
+        return None
+
+
+def _v117_latent_cache_ok(path: Path, width: int, height: int) -> bool:
     import numpy as np
 
-    valid: set[str] = set()
-    for path in root.rglob("*_anima.npz"):
-        try:
-            match = re.match(r"^(.*)_(\d+)x(\d+)_anima$", path.stem)
-            if not match:
-                continue
-            width = int(match.group(2))
-            height = int(match.group(3))
-            if width % 8 or height % 8:
-                continue
-            suffix = f"_{height // 8}x{width // 8}"
-            latent_key = f"latents{suffix}"
-            original_size_key = f"original_size{suffix}"
-            crop_ltrb_key = f"crop_ltrb{suffix}"
-            with np.load(path, allow_pickle=False) as data:
-                if not {
-                    latent_key,
-                    original_size_key,
-                    crop_ltrb_key,
-                }.issubset(data.files):
-                    continue
-                latents = data[latent_key]
-                if (
-                    latents.ndim < 3
-                    or latents.shape[-2:] != (height // 8, width // 8)
-                    or data[original_size_key].shape != (2,)
-                    or data[crop_ltrb_key].shape != (4,)
-                ):
-                    continue
-                valid.add(match.group(1))
-        except Exception:
-            continue
-    return valid
-
-
-def _v117_latent_cache_file_stems(root: Path) -> set[str]:
-    stems: set[str] = set()
-    for path in root.rglob("*_anima.npz"):
-        match = re.match(r"^(.*)_(\d+)x(\d+)_anima$", path.stem)
-        if path.is_file() and match:
-            stems.add(match.group(1))
-    return stems
+    if width % 8 or height % 8:
+        return False
+    suffix = f"_{height // 8}x{width // 8}"
+    latent_key = f"latents{suffix}"
+    original_size_key = f"original_size{suffix}"
+    crop_ltrb_key = f"crop_ltrb{suffix}"
+    try:
+        with np.load(path, allow_pickle=False) as data:
+            if not {latent_key, original_size_key, crop_ltrb_key}.issubset(data.files):
+                return False
+            latents = data[latent_key]
+            return bool(
+                latents.ndim >= 3
+                and latents.shape[-2:] == (height // 8, width // 8)
+                and data[original_size_key].shape == (2,)
+                and data[crop_ltrb_key].shape == (4,)
+            )
+    except Exception:
+        return False
 
 
 def _v117_text_cache_layout(
@@ -396,60 +389,43 @@ def _v117_text_cache_layout(
     return required if set(required).issubset(keys) else None
 
 
-def _v117_text_cache_stems(
-    root: Path | None,
+def _v117_text_cache_ok(
+    path: Path,
     *,
-    cache_llm_adapter_outputs: bool = True,
-) -> set[str]:
-    if root is None or not root.is_dir():
-        return set()
+    cache_llm_adapter_outputs: bool,
+) -> bool:
     from safetensors import safe_open
 
-    valid: set[str] = set()
-    for path in root.rglob("*_anima_te.safetensors"):
-        try:
-            with safe_open(path, framework="pt", device="cpu") as handle:
-                keys = set(handle.keys())
-                if "caption_dropout_rate" not in keys:
-                    continue
-                if "num_variants" not in keys:
-                    complete = (
-                        _v117_text_cache_layout(keys, cache_llm_adapter_outputs)
-                        is not None
-                    )
-                else:
-                    num_variants = int(handle.get_tensor("num_variants"))
-                    layout = _v117_text_cache_layout(
-                        keys,
-                        cache_llm_adapter_outputs,
-                        "_v0",
-                    )
-                    complete = num_variants > 0 and layout is not None
-                    if complete:
-                        stems = tuple(key.removesuffix("_v0") for key in layout)
-                        complete = all(
-                            all(f"{stem}_v{index}" in keys for stem in stems)
-                            for index in range(num_variants)
-                        )
-                        if complete and "num_randomized" in keys:
-                            num_randomized = int(handle.get_tensor("num_randomized"))
-                            complete = num_randomized > 0 and all(
-                                all(f"{stem}_r{index}" in keys for stem in stems)
-                                for index in range(1, num_randomized + 1)
-                            )
-            if complete:
-                valid.add(path.name.removesuffix("_anima_te.safetensors"))
-        except Exception:
-            continue
-    return valid
-
-
-def _v117_text_cache_file_stems(root: Path) -> set[str]:
-    return {
-        path.name.removesuffix("_anima_te.safetensors")
-        for path in root.rglob("*_anima_te.safetensors")
-        if path.is_file()
-    }
+    try:
+        with safe_open(path, framework="pt", device="cpu") as handle:
+            keys = set(handle.keys())
+            if "caption_dropout_rate" not in keys:
+                return False
+            if "num_variants" not in keys:
+                return (
+                    _v117_text_cache_layout(keys, cache_llm_adapter_outputs)
+                    is not None
+                )
+            num_variants = int(handle.get_tensor("num_variants"))
+            layout = _v117_text_cache_layout(keys, cache_llm_adapter_outputs, "_v0")
+            if num_variants <= 0 or layout is None:
+                return False
+            stems = tuple(key.removesuffix("_v0") for key in layout)
+            if not all(
+                all(f"{stem}_v{index}" in keys for stem in stems)
+                for index in range(num_variants)
+            ):
+                return False
+            if "num_randomized" in keys:
+                num_randomized = int(handle.get_tensor("num_randomized"))
+                if num_randomized <= 0 or not all(
+                    all(f"{stem}_r{index}" in keys for stem in stems)
+                    for index in range(1, num_randomized + 1)
+                ):
+                    return False
+            return True
+    except Exception:
+        return False
 
 
 def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: DependencyProbe = default_dependency_probe) -> PreflightResult:
@@ -550,14 +526,6 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
         facts["dataset_image_count"] = len(images)
         if not images:
             errors.append(f"no training images found under {train_dir}")
-        stems: dict[str, Path] = {}
-        duplicates: list[str] = []
-        for image in images:
-            if image.stem in stems:
-                duplicates.append(image.stem)
-            stems[image.stem] = image
-        if duplicates:
-            errors.append("duplicate image stems would collide in anima_lora flat cache: " + ", ".join(sorted(set(duplicates))[:8]))
         captioned = sum(1 for image in images if image.with_suffix(".txt").is_file())
         if images and captioned < len(images):
             warnings.append(f"{len(images) - captioned} image(s) do not have .txt captions")
@@ -621,38 +589,66 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
         else:
             cache_dir_ready = True
     if resized_images and cache_dir_ready:
-        expected_stems = {image.stem for image in resized_images}
-        if cache_latents:
-            missing = expected_stems - _v117_latent_cache_file_stems(lora_cache_dir)
-            if missing:
-                errors.append(
-                    "use_vae_cache=true is missing cache files for resized images: "
-                    + ", ".join(sorted(missing)[:8])
-                )
-            elif not skip_cache_check:
-                latent_stems = _v117_latent_cache_stems(lora_cache_dir)
-                if expected_stems - latent_stems:
-                    errors.append(
-                        "use_vae_cache=true requires completed Anima preprocess/cache files; "
-                        "disable use_vae_cache for live VAE encoding or run preprocess first"
+        missing_latents: list[str] = []
+        invalid_latents: list[str] = []
+        missing_text: list[str] = []
+        invalid_text: list[str] = []
+        unreadable: list[str] = []
+        for image in resized_images:
+            rel = image.relative_to(resized_dir).with_suffix("")
+            identity = rel.as_posix()
+            if cache_latents:
+                size = _image_pixel_size(image)
+                if size is None:
+                    unreadable.append(identity)
+                else:
+                    width, height = size
+                    npz = (
+                        lora_cache_dir
+                        / rel.parent
+                        / f"{rel.name}_{width:04d}x{height:04d}_anima.npz"
                     )
-        if cache_text_encoder:
-            missing = expected_stems - _v117_text_cache_file_stems(lora_cache_dir)
-            if missing:
-                errors.append(
-                    "use_text_cache=true is missing cache files for resized images: "
-                    + ", ".join(sorted(missing)[:8])
-                )
-            elif not skip_cache_check:
-                text_stems = _v117_text_cache_stems(
-                    lora_cache_dir,
-                    cache_llm_adapter_outputs=cache_llm_adapter_outputs,
-                )
-                if expected_stems - text_stems:
-                    errors.append(
-                        "use_text_cache=true requires completed Anima text encoder cache; "
-                        "disable use_text_cache for live encoding or run preprocess first"
-                    )
+                    if not npz.is_file():
+                        missing_latents.append(identity)
+                    elif not skip_cache_check and not _v117_latent_cache_ok(
+                        npz, width, height
+                    ):
+                        invalid_latents.append(identity)
+            if cache_text_encoder:
+                te = lora_cache_dir / rel.parent / f"{rel.name}_anima_te.safetensors"
+                if not te.is_file():
+                    missing_text.append(identity)
+                elif not skip_cache_check and not _v117_text_cache_ok(
+                    te, cache_llm_adapter_outputs=cache_llm_adapter_outputs
+                ):
+                    invalid_text.append(identity)
+        if unreadable:
+            errors.append(
+                "cannot read image dimensions for resized images: "
+                + ", ".join(sorted(unreadable)[:8])
+            )
+        if missing_latents:
+            errors.append(
+                "use_vae_cache=true is missing cache files for resized images: "
+                + ", ".join(sorted(missing_latents)[:8])
+            )
+        elif invalid_latents:
+            errors.append(
+                "use_vae_cache=true requires completed Anima preprocess/cache files; "
+                "disable use_vae_cache for live VAE encoding or run preprocess first: "
+                + ", ".join(sorted(invalid_latents)[:8])
+            )
+        if missing_text:
+            errors.append(
+                "use_text_cache=true is missing cache files for resized images: "
+                + ", ".join(sorted(missing_text)[:8])
+            )
+        elif invalid_text:
+            errors.append(
+                "use_text_cache=true requires completed Anima text encoder cache; "
+                "disable use_text_cache for live encoding or run preprocess first: "
+                + ", ".join(sorted(invalid_text)[:8])
+            )
 
     if not errors:
         dep = probe(runtime)

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -80,6 +80,46 @@ def save_minimal_resume_state(path: Path) -> None:
     )
 
 
+def write_png(path: Path, width: int = 64, height: int = 64) -> None:
+    from PIL import Image
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with Image.new("RGB", (width, height)) as image:
+        image.save(path, format="PNG")
+
+
+def save_latent_npz(path: Path, width: int, height: int) -> None:
+    import numpy as np
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = f"{height // 8}x{width // 8}"
+    np.savez(
+        path,
+        **{
+            f"latents_{key}": np.zeros((16, 1, height // 8, width // 8)),
+            f"original_size_{key}": np.zeros((2,)),
+            f"crop_ltrb_{key}": np.zeros((4,)),
+        },
+    )
+
+
+def save_text_cache(path: Path) -> None:
+    import torch
+    from safetensors.torch import save_file
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    save_file(
+        {
+            "caption_dropout_rate": torch.zeros(1),
+            "prompt_embeds": torch.zeros(1),
+            "attn_mask": torch.zeros(1),
+            "t5_input_ids": torch.zeros(1),
+            "t5_attn_mask": torch.zeros(1),
+        },
+        path,
+    )
+
+
 class ServiceResolverTests(unittest.TestCase):
     def test_legacy_resolver_does_not_expose_monitor_port(self):
         resolver = LegacyServiceResolverShim({"MIKAZUKI_HOST": "0.0.0.0", "MIKAZUKI_PORT": "28000", "TRAIN_MONITOR_PORT": "6008"})
@@ -730,7 +770,7 @@ class PreflightLauncherTests(unittest.TestCase):
             for stem in ("a", "b"):
                 (dataset / f"{stem}.png").write_bytes(b"png")
                 (dataset / f"{stem}.txt").write_text("caption", encoding="utf-8")
-                (resized / f"{stem}.png").write_bytes(b"png")
+                write_png(resized / f"{stem}.png", 1024, 1024)
 
             if cache_state != "missing_directory":
                 cache.mkdir()
@@ -1297,21 +1337,33 @@ class PreflightLauncherTests(unittest.TestCase):
                 latents_96x128=np.zeros((1,)),
             )
 
-            self.assertEqual(preflight_module._v117_latent_cache_stems(cache), set())
-
-    def test_v117_latent_cache_accepts_matching_non_square_bucket_key(self):
-        import numpy as np
-
-        with tempfile.TemporaryDirectory() as td:
-            cache = Path(td)
-            np.savez(
-                cache / "a_1024x768_anima.npz",
-                latents_96x128=np.zeros((16, 1, 96, 128)),
-                original_size_96x128=np.zeros((2,)),
-                crop_ltrb_96x128=np.zeros((4,)),
+            self.assertFalse(
+                preflight_module._v117_latent_cache_ok(
+                    cache / "a_1024x1024_anima.npz", 1024, 1024
+                )
             )
 
-            self.assertEqual(preflight_module._v117_latent_cache_stems(cache), {"a"})
+    def test_v117_latent_cache_accepts_matching_non_square_bucket_key(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            save_latent_npz(cache / "a_1024x768_anima.npz", 1024, 768)
+
+            self.assertTrue(
+                preflight_module._v117_latent_cache_ok(
+                    cache / "a_1024x768_anima.npz", 1024, 768
+                )
+            )
+
+    def test_v117_latent_cache_rejects_resolution_mismatch(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache = Path(td)
+            save_latent_npz(cache / "a_0064x0064_anima.npz", 64, 64)
+
+            self.assertFalse(
+                preflight_module._v117_latent_cache_ok(
+                    cache / "a_0064x0064_anima.npz", 1024, 768
+                )
+            )
 
     def test_v117_latent_cache_requires_bucket_metadata_keys(self):
         import numpy as np
@@ -1327,7 +1379,11 @@ class PreflightLauncherTests(unittest.TestCase):
                 del arrays[missing_key]
                 np.savez(cache / "a_1024x768_anima.npz", **arrays)
 
-                self.assertEqual(preflight_module._v117_latent_cache_stems(cache), set())
+                self.assertFalse(
+                    preflight_module._v117_latent_cache_ok(
+                        cache / "a_1024x768_anima.npz", 1024, 768
+                    )
+                )
 
     def test_v117_latent_cache_rejects_invalid_shapes(self):
         import numpy as np
@@ -1355,7 +1411,11 @@ class PreflightLauncherTests(unittest.TestCase):
                     cache = Path(td)
                     np.savez(cache / "a_1024x768_anima.npz", **arrays)
 
-                    self.assertEqual(preflight_module._v117_latent_cache_stems(cache), set())
+                    self.assertFalse(
+                        preflight_module._v117_latent_cache_ok(
+                            cache / "a_1024x768_anima.npz", 1024, 768
+                        )
+                    )
 
     def test_v117_text_cache_requires_t5_attention_mask(self):
         import torch
@@ -1371,7 +1431,12 @@ class PreflightLauncherTests(unittest.TestCase):
                 cache / "a_anima_te.safetensors",
             )
 
-            self.assertEqual(preflight_module._v117_text_cache_stems(cache), set())
+            self.assertFalse(
+                preflight_module._v117_text_cache_ok(
+                    cache / "a_anima_te.safetensors",
+                    cache_llm_adapter_outputs=True,
+                )
+            )
 
     def test_v117_text_cache_requires_caption_dropout_rate(self):
         import torch
@@ -1389,7 +1454,12 @@ class PreflightLauncherTests(unittest.TestCase):
                 cache / "a_anima_te.safetensors",
             )
 
-            self.assertEqual(preflight_module._v117_text_cache_stems(cache), set())
+            self.assertFalse(
+                preflight_module._v117_text_cache_ok(
+                    cache / "a_anima_te.safetensors",
+                    cache_llm_adapter_outputs=False,
+                )
+            )
 
     def test_v117_text_cache_requires_complete_variant_key_groups(self):
         import torch
@@ -1408,7 +1478,12 @@ class PreflightLauncherTests(unittest.TestCase):
                 cache / "a_anima_te.safetensors",
             )
 
-            self.assertEqual(preflight_module._v117_text_cache_stems(cache), set())
+            self.assertFalse(
+                preflight_module._v117_text_cache_ok(
+                    cache / "a_anima_te.safetensors",
+                    cache_llm_adapter_outputs=True,
+                )
+            )
 
     def test_v117_text_cache_accepts_complete_variant_key_groups(self):
         import torch
@@ -1428,7 +1503,12 @@ class PreflightLauncherTests(unittest.TestCase):
                 cache / "a_anima_te.safetensors",
             )
 
-            self.assertEqual(preflight_module._v117_text_cache_stems(cache), {"a"})
+            self.assertTrue(
+                preflight_module._v117_text_cache_ok(
+                    cache / "a_anima_te.safetensors",
+                    cache_llm_adapter_outputs=True,
+                )
+            )
 
     def test_preflight_adapter_cache_mode_rejects_plain_text_cache(self):
         result = self._run_text_cache_preflight(
@@ -1504,7 +1584,7 @@ class PreflightLauncherTests(unittest.TestCase):
             for stem in ("a", "b"):
                 (dataset / f"{stem}.png").write_bytes(b"png")
                 (dataset / f"{stem}.txt").write_text("caption", encoding="utf-8")
-                (resized / f"{stem}.png").write_bytes(b"png")
+                write_png(resized / f"{stem}.png", 1024, 1024)
             np.savez(cache / "a_1024x1024_anima.npz", latents_1024x1024=np.zeros((1,)))
             save_file(
                 {
@@ -1630,7 +1710,7 @@ class PreflightLauncherTests(unittest.TestCase):
             cache.mkdir()
             (dataset / "a.png").write_text("", encoding="utf-8")
             (dataset / "a.txt").write_text("caption", encoding="utf-8")
-            (resized / "a.png").write_text("", encoding="utf-8")
+            write_png(resized / "a.png", 64, 64)
 
             result = run_preflight({
                 "pretrained_model_name_or_path": "model.safetensors",
@@ -1722,6 +1802,189 @@ class PreflightLauncherTests(unittest.TestCase):
                 )
 
                 self.assertTrue(result.ok, result.errors)
+
+    def test_preflight_rejects_latent_cache_with_wrong_resolution(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            save_anima_model(root / "model.safetensors")
+            for name in ("vae.safetensors", "qwen.safetensors"):
+                (root / name).write_bytes(b"x")
+            dataset = root / "dataset"
+            resized = root / "resized"
+            cache = root / "cache"
+            dataset.mkdir()
+            resized.mkdir()
+            cache.mkdir()
+            (dataset / "a.png").write_bytes(b"png")
+            (dataset / "a.txt").write_text("caption", encoding="utf-8")
+            write_png(resized / "a.png", 1024, 768)
+            save_latent_npz(cache / "a_0064x0064_anima.npz", 64, 64)
+
+            result = run_preflight(
+                {
+                    "pretrained_model_name_or_path": str(root / "model.safetensors"),
+                    "vae": str(root / "vae.safetensors"),
+                    "qwen3": str(root / "qwen.safetensors"),
+                    "train_data_dir": str(dataset),
+                    "resized_image_dir": str(resized),
+                    "lora_cache_dir": str(cache),
+                    "use_vae_cache": True,
+                    "torch_compile": False,
+                    "attn_mode": "torch",
+                },
+                runtime,
+                lambda _runtime: ProbeFacts(
+                    "3.13.11",
+                    torch_metadata_version="2.11.0+cu130",
+                    cuda_available=True,
+                ),
+            )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(
+                "use_vae_cache=true is missing cache files" in error and "a" in error
+                for error in result.errors
+            ),
+            result.errors,
+        )
+
+    def test_preflight_rejects_text_cache_in_wrong_subdirectory(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            save_anima_model(root / "model.safetensors")
+            for name in ("vae.safetensors", "qwen.safetensors"):
+                (root / name).write_bytes(b"x")
+            dataset = root / "dataset"
+            resized = root / "resized"
+            cache = root / "cache"
+            dataset.mkdir()
+            cache.mkdir()
+            (dataset / "a.png").write_bytes(b"png")
+            (dataset / "a.txt").write_text("caption", encoding="utf-8")
+            write_png(resized / "foo" / "a.png", 1024, 768)
+            save_text_cache(cache / "bar" / "a_anima_te.safetensors")
+
+            result = run_preflight(
+                {
+                    "pretrained_model_name_or_path": str(root / "model.safetensors"),
+                    "vae": str(root / "vae.safetensors"),
+                    "qwen3": str(root / "qwen.safetensors"),
+                    "train_data_dir": str(dataset),
+                    "resized_image_dir": str(resized),
+                    "lora_cache_dir": str(cache),
+                    "use_text_cache": True,
+                    "torch_compile": False,
+                    "attn_mode": "torch",
+                },
+                runtime,
+                lambda _runtime: ProbeFacts(
+                    "3.13.11",
+                    torch_metadata_version="2.11.0+cu130",
+                    cuda_available=True,
+                ),
+            )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(
+                "use_text_cache=true is missing cache files" in error
+                and "foo/a" in error
+                for error in result.errors
+            ),
+            result.errors,
+        )
+
+    def test_preflight_allows_same_stem_images_in_different_subdirectories(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            save_anima_model(root / "model.safetensors")
+            for name in ("vae.safetensors", "qwen.safetensors"):
+                (root / name).write_bytes(b"x")
+            dataset = root / "dataset"
+            resized = root / "resized"
+            cache = root / "cache"
+            for subdir in ("one", "two"):
+                (dataset / subdir).mkdir(parents=True)
+                write_png(dataset / subdir / "a.png", 64, 64)
+                (dataset / subdir / "a.txt").write_text("caption", encoding="utf-8")
+                write_png(resized / subdir / "a.png", 64, 64)
+                save_latent_npz(cache / subdir / "a_0064x0064_anima.npz", 64, 64)
+                save_text_cache(cache / subdir / "a_anima_te.safetensors")
+
+            result = run_preflight(
+                {
+                    "pretrained_model_name_or_path": str(root / "model.safetensors"),
+                    "vae": str(root / "vae.safetensors"),
+                    "qwen3": str(root / "qwen.safetensors"),
+                    "train_data_dir": str(dataset),
+                    "resized_image_dir": str(resized),
+                    "lora_cache_dir": str(cache),
+                    "use_vae_cache": True,
+                    "use_text_cache": True,
+                    "torch_compile": False,
+                    "attn_mode": "torch",
+                },
+                runtime,
+                lambda _runtime: ProbeFacts(
+                    "3.13.11",
+                    torch_metadata_version="2.11.0+cu130",
+                    cuda_available=True,
+                ),
+            )
+
+        self.assertTrue(result.ok, result.errors)
+
+    def test_preflight_skip_cache_check_still_rejects_wrong_resolution_latent(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            save_anima_model(root / "model.safetensors")
+            for name in ("vae.safetensors", "qwen.safetensors"):
+                (root / name).write_bytes(b"x")
+            dataset = root / "dataset"
+            resized = root / "resized"
+            cache = root / "cache"
+            dataset.mkdir()
+            resized.mkdir()
+            cache.mkdir()
+            (dataset / "a.png").write_bytes(b"png")
+            (dataset / "a.txt").write_text("caption", encoding="utf-8")
+            write_png(resized / "a.png", 1024, 768)
+            save_latent_npz(cache / "a_0064x0064_anima.npz", 64, 64)
+
+            result = run_preflight(
+                {
+                    "pretrained_model_name_or_path": str(root / "model.safetensors"),
+                    "vae": str(root / "vae.safetensors"),
+                    "qwen3": str(root / "qwen.safetensors"),
+                    "train_data_dir": str(dataset),
+                    "resized_image_dir": str(resized),
+                    "lora_cache_dir": str(cache),
+                    "use_vae_cache": True,
+                    "skip_cache_check": True,
+                    "torch_compile": False,
+                    "attn_mode": "torch",
+                },
+                runtime,
+                lambda _runtime: ProbeFacts(
+                    "3.13.11",
+                    torch_metadata_version="2.11.0+cu130",
+                    cuda_available=True,
+                ),
+            )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(
+                "use_vae_cache=true is missing cache files" in error
+                for error in result.errors
+            ),
+            result.errors,
+        )
 
     def test_preflight_allows_live_encoding_without_preprocess_cache(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
- 分支：`fix/anima-fast-preflight-cache-path-mapping`
- 基线：`codex/anima-fast-main-refresh`（`9e0637d`）
- Commit：`99d71ad` fix(anima-fast): align preflight cache identity with v1.17.1 relative paths
- 改动规模：2 个文件，+411 / -152
## 背景
Issue #331 确认预检把缓存身份压平为 basename stem，导致三个问题：错误尺寸 latent 缓存可通过、错误子目录 text 缓存可通过、不同子目录同名图片被误判冲突。本次对齐 upstream（pin `b43928b5`）`resolve_cache_path` 的真实映射：`cache_dir / relpath(dirname(image), image_dir) / {stem}{suffix}`。
## mikazuki/anima_fast_backend/preflight.py（+112 / -152 净重构）
**删除**
- `_v117_latent_cache_stems()` / `_v117_latent_cache_file_stems()`：全目录 rglob 后按 stem 聚合的存在性/内容检查
- `_v117_text_cache_stems()` / `_v117_text_cache_file_stems()`：同上（text 侧）
- train_data_dir 的同名 stem 冲突报错（"duplicate image stems would collide in anima_lora flat cache"）
**新增**
- `_image_pixel_size(path)`：读图片 header 拿真实 `(W, H)`，优先 `imagesize`（requirements 已钉 1.4.1），PIL 兜底，失败返回 None
- `_v117_latent_cache_ok(path, width, height)`：对**精确文件**做内容校验——`latents_{H//8}x{W//8}` / `original_size_*` / `crop_ltrb_*` 三 key 齐全且 shape 与 `(W, H)` 匹配（沿用旧校验语义）
- `_v117_text_cache_ok(path, *, cache_llm_adapter_outputs)`：对**精确文件**做 key 布局校验——`caption_dropout_rate` 必需；plain 模式四件套 / adapter 模式 `crossattn_emb + t5_attn_mask`；`num_variants` / `num_randomized` 家族完整性（沿用旧校验语义）
**run_preflight() 缓存段重写**
- 缓存身份：`image.relative_to(resized_image_dir).with_suffix("")` 的 posix 相对路径（如 `foo/a`），不再用 basename stem
- latent 存在性：逐图片要求精确文件 `lora_cache_dir / <relparent> / {stem}_{W:04d}x{H:04d}_anima.npz`（W/H 来自图片真实尺寸）
- text 存在性：逐图片要求精确文件 `lora_cache_dir / <relparent> / {stem}_anima_te.safetensors`
- 内容校验（非 skip 时）针对每张图对应的精确文件，报错附相对身份清单
- `skip_cache_check=true`：仍检查精确文件存在，只跳内容校验
- 新增错误：resized 图片读不出尺寸时报 `cannot read image dimensions for resized images: ...`（此时无法定位缓存文件）
## tests/test_anima_fast_backend.py（+299）
**新增模块级夹具**
- `write_png(path, width, height)`：PIL 生成真实 PNG（header 可读）
- `save_latent_npz(path, width, height)`：构造内容合法的 `{stem}_{WxH}_anima.npz`
- `save_text_cache(path)`：构造 plain 布局的合法 `{stem}_anima_te.safetensors`
**单元测试改写**（原直接调已删除的集合函数，改为逐文件 API）
- `test_v117_latent_cache_requires_bucket_specific_key`
- `test_v117_latent_cache_accepts_matching_non_square_bucket_key`
- `test_v117_latent_cache_requires_bucket_metadata_keys`
- `test_v117_latent_cache_rejects_invalid_shapes`
- `test_v117_text_cache_requires_t5_attention_mask`
- `test_v117_text_cache_requires_caption_dropout_rate`
- `test_v117_text_cache_requires_complete_variant_key_groups`
- `test_v117_text_cache_accepts_complete_variant_key_groups`
- 新增 `test_v117_latent_cache_rejects_resolution_mismatch`（同文件内容合法但尺寸不匹配 → 拒绝）
**issue 三个场景的公开 run_preflight() 回归（新增）**
1. `test_preflight_rejects_latent_cache_with_wrong_resolution`：`1024x768/a.png` + 内容完整的 `a_0064x0064_anima.npz` → 拒绝
2. `test_preflight_rejects_text_cache_in_wrong_subdirectory`：`foo/a.png` + `bar/a_anima_te.safetensors` → 拒绝
3. `test_preflight_allows_same_stem_images_in_different_subdirectories`：`one/a.png` 与 `two/a.png` 缓存各自齐全 → 通过（不再报 stem 冲突）
4. `test_preflight_skip_cache_check_still_rejects_wrong_resolution_latent`：skip 模式下错误尺寸的精确文件仍算缺失 → 拒绝
**既有夹具适配**（预检现在会读 resized 图片 header，假 png 字节不可用）
- `_run_skip_cache_preflight`：resized 图片改为真实 1024x1024 PNG
- `test_preflight_rejects_incomplete_v117_cache_sets`：同上
- `test_preflight_rejects_cache_flags_without_preprocess_cache`：resized/a.png 改为真实 64x64 PNG
## 验证结果
- 聚焦：`pytest tests/test_anima_fast_backend.py -q` → **87 passed, 32 subtests passed**
- 全量：`pytest tests -q` 失败清单与基线 `9e0637d` **逐项 diff 一致**（均为 main 线遗留失败，非本次引入）

需要逐步真机验证