### PR TITLE
fix(anima-fast): guard torch attention with compile

### DIFF
--- a/frontend/src/components/DynamicSchemaForm.test.ts
+++ b/frontend/src/components/DynamicSchemaForm.test.ts
@@ -71,4 +71,35 @@ describe("DynamicSchemaForm", () => {
     await wrapper.setProps({ modelValue: { attn_mode: "torch", torch_compile: false } })
     expect(wrapper.get('[data-key="torch_compile"]').attributes("data-disabled")).toBe("true")
   })
+
+  it("treats empty attention as torch when guarding torch_compile", () => {
+    const guardedSchema: AdaptedSchema = {
+      ...schema,
+      sections: [{
+        ...schema.sections[0],
+        fields: [
+          { key: "attn_mode", type: "string", options: ["", "torch", "flash"], conditions: [] },
+          { key: "torch_compile", type: "boolean", conditions: [] },
+        ],
+      }],
+    }
+    const wrapper = mount(DynamicSchemaForm, {
+      props: {
+        schema: guardedSchema,
+        modelValue: { attn_mode: "", torch_compile: true },
+        errors: {},
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          SchemaField: {
+            props: ["field"],
+            template: "<button :data-key=\"field.key\" :data-disabled=\"field.disabled\">{{ field.key }}</button>",
+          },
+        },
+      },
+    })
+
+    expect(wrapper.get('[data-key="torch_compile"]').attributes("data-disabled")).toBe("true")
+  })
 })

--- a/frontend/src/components/DynamicSchemaForm.test.ts
+++ b/frontend/src/components/DynamicSchemaForm.test.ts
@@ -34,4 +34,41 @@ describe("DynamicSchemaForm", () => {
     await wrapper.get("button").trigger("click")
     expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([{ mode: 12 }])
   })
+
+  it("disables and clears torch_compile when torch attention is selected", async () => {
+    const guardedSchema: AdaptedSchema = {
+      ...schema,
+      sections: [{
+        ...schema.sections[0],
+        fields: [
+          { key: "attn_mode", type: "string", options: ["torch", "flash"], conditions: [] },
+          { key: "torch_compile", type: "boolean", conditions: [] },
+        ],
+      }],
+    }
+    const wrapper = mount(DynamicSchemaForm, {
+      props: {
+        schema: guardedSchema,
+        modelValue: { attn_mode: "flash", torch_compile: true },
+        errors: {},
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          SchemaField: {
+            props: ["field", "modelValue"],
+            template: "<button :data-key=\"field.key\" :data-disabled=\"field.disabled\" @click=\"$emit('update:modelValue', field.key === 'attn_mode' ? 'torch' : false)\">{{ field.key }}</button>",
+          },
+        },
+      },
+    })
+
+    await wrapper.get('[data-key="attn_mode"]').trigger("click")
+
+    expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([
+      { attn_mode: "torch", torch_compile: false },
+    ])
+    await wrapper.setProps({ modelValue: { attn_mode: "torch", torch_compile: false } })
+    expect(wrapper.get('[data-key="torch_compile"]').attributes("data-disabled")).toBe("true")
+  })
 })

--- a/frontend/src/components/DynamicSchemaForm.vue
+++ b/frontend/src/components/DynamicSchemaForm.vue
@@ -2,7 +2,7 @@
 import { computed } from "vue"
 import { useI18n } from "vue-i18n"
 import type { AdaptedSchema, FormField, FormModel } from "../schema/adapter"
-import { isFieldActive } from "../schema/adapter"
+import { isAnimaFastTorchCompileBlocked, isFieldActive } from "../schema/adapter"
 import SchemaField from "./SchemaField.vue"
 
 const props = defineProps<{ schema: AdaptedSchema; modelValue: FormModel; errors: Record<string, string> }>()
@@ -23,8 +23,19 @@ function visibleFields(fields: FormField[]) {
   return fields.filter((field) => !field.hidden && selectedFields.value.get(field.key) === field)
 }
 
+function presentedField(field: FormField): FormField {
+  if (field.key !== "torch_compile") return field
+  return {
+    ...field,
+    disabled: field.disabled || isAnimaFastTorchCompileBlocked(props.modelValue),
+    description: `${field.description || ""} attn_mode=torch 时会因 #336 禁用 torch_compile；请关闭该选项或改用受支持的 attention 模式。`.trim(),
+  }
+}
+
 function update(key: string, value: FormModel[string]) {
-  emit("update:modelValue", { ...props.modelValue, [key]: value })
+  const next = { ...props.modelValue, [key]: value }
+  if (key === "attn_mode" && value === "torch") next.torch_compile = false
+  emit("update:modelValue", next)
 }
 </script>
 
@@ -34,7 +45,7 @@ function update(key: string, value: FormModel[string]) {
       <header><h2>{{ section.title }}</h2><span>{{ t("schemaForm.fieldCount", { n: visibleFields(section.fields).length }) }}</span></header>
       <slot :name="`tools-${section.id}`" />
       <div class="schema-fields">
-        <SchemaField v-for="field in visibleFields(section.fields)" :key="field.key" :field="field" :model-value="modelValue[field.key]" :error="errors[field.key]" @update:model-value="update(field.key, $event)" />
+        <SchemaField v-for="field in visibleFields(section.fields)" :key="field.key" :field="presentedField(field)" :model-value="modelValue[field.key]" :error="errors[field.key]" @update:model-value="update(field.key, $event)" />
       </div>
     </section>
   </div>

--- a/frontend/src/components/DynamicSchemaForm.vue
+++ b/frontend/src/components/DynamicSchemaForm.vue
@@ -34,7 +34,7 @@ function presentedField(field: FormField): FormField {
 
 function update(key: string, value: FormModel[string]) {
   const next = { ...props.modelValue, [key]: value }
-  if (key === "attn_mode" && value === "torch") next.torch_compile = false
+  if (key === "attn_mode" && isAnimaFastTorchCompileBlocked(next)) next.torch_compile = false
   emit("update:modelValue", next)
 }
 </script>

--- a/frontend/src/schema/adapter.ts
+++ b/frontend/src/schema/adapter.ts
@@ -190,6 +190,10 @@ export function isFieldActive(field: FormField, model: FormModel) {
   return field.conditions.every((condition) => model[condition.key] === condition.value)
 }
 
+export function isAnimaFastTorchCompileBlocked(model: FormModel) {
+  return model.attn_mode === "torch"
+}
+
 export function createDefaultModel(schema: AdaptedSchema): FormModel {
   const model: FormModel = {}
   for (const field of schema.sections.flatMap((section) => section.fields)) {
@@ -217,6 +221,10 @@ export function serializeModel(schema: AdaptedSchema, model: FormModel) {
   const output: FormModel = {}
   for (const field of schema.sections.flatMap((section) => section.fields)) {
     if (!isFieldActive(field, model)) continue
+    if (field.key === "torch_compile" && isAnimaFastTorchCompileBlocked(model)) {
+      output[field.key] = false
+      continue
+    }
     const value = field.type === "const" ? field.constValue : model[field.key]
     if (value === undefined || value === "" || (Array.isArray(value) && !value.length)) continue
     output[field.key] = cloneFormValue(value)
@@ -236,6 +244,9 @@ export function validateModel(schema: AdaptedSchema, model: FormModel) {
     } else if (typeof value === "number" && field.max !== undefined && value > field.max) {
       errors[field.key] = i18n.global.t("schema.tooLarge", { max: field.max })
     }
+  }
+  if (isAnimaFastTorchCompileBlocked(model) && model.torch_compile === true) {
+    errors.torch_compile = "attn_mode=torch cannot be combined with torch_compile=true (#336); disable torch_compile or choose a supported attention mode"
   }
   return errors
 }

--- a/frontend/src/schema/adapter.ts
+++ b/frontend/src/schema/adapter.ts
@@ -191,7 +191,8 @@ export function isFieldActive(field: FormField, model: FormModel) {
 }
 
 export function isAnimaFastTorchCompileBlocked(model: FormModel) {
-  return model.attn_mode === "torch"
+  const attnMode = typeof model.attn_mode === "string" ? model.attn_mode.trim() : ""
+  return !attnMode || attnMode === "torch"
 }
 
 export function createDefaultModel(schema: AdaptedSchema): FormModel {

--- a/mikazuki/anima_fast_backend/adapter.py
+++ b/mikazuki/anima_fast_backend/adapter.py
@@ -450,6 +450,14 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
     if is_empty(values.get("attn_mode")):
         values["attn_mode"] = "torch"
         warnings.append("attn_mode 留空时使用 torch 保底；如需 flash 请先确认插件环境已安装 flash-attn")
+    if values["attn_mode"] == "torch" and truthy(values.get("torch_compile")):
+        if "torch_compile" in source:
+            raise AdapterError(
+                "attn_mode=torch cannot be combined with torch_compile=true in Anima Fast "
+                "(#336); disable torch_compile or choose a supported attention mode"
+            )
+        values["torch_compile"] = False
+        warnings.append("torch_compile was disabled because attn_mode=torch is incompatible with #336")
     values["method"] = "lora"
     values["methods_subdir"] = "gui-methods"
     values["network_module"] = "networks.lora_anima"

--- a/mikazuki/anima_fast_backend/adapter.py
+++ b/mikazuki/anima_fast_backend/adapter.py
@@ -438,7 +438,7 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
 
     normalize_bucket_resolution(values, warnings)
 
-    values.setdefault("torch_compile", True)
+    values.setdefault("torch_compile", False)
     values.setdefault("compile_dynamic_seq", True)
     if truthy(values.get("torch_compile")) and not truthy(values.get("compile_dynamic_seq")):
         values["compile_dynamic_seq"] = True
@@ -451,7 +451,7 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
         values["attn_mode"] = "torch"
         warnings.append("attn_mode 留空时使用 torch 保底；如需 flash 请先确认插件环境已安装 flash-attn")
     if values["attn_mode"] == "torch" and truthy(values.get("torch_compile")):
-        if "torch_compile" in source:
+        if truthy(source.get("torch_compile")):
             raise AdapterError(
                 "attn_mode=torch cannot be combined with torch_compile=true in Anima Fast "
                 "(#336); disable torch_compile or choose a supported attention mode"

--- a/mikazuki/anima_fast_backend/preflight.py
+++ b/mikazuki/anima_fast_backend/preflight.py
@@ -545,7 +545,8 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
     facts["resolution_tokens"] = tokens
     if torch_compile and not _truthy(config.get("compile_dynamic_seq", True)):
         errors.append("torch_compile requires compile_dynamic_seq with Anima v1.17.1 free-fit buckets")
-    if str(config.get("attn_mode", "")).strip() == "torch" and torch_compile:
+    attn_mode = str(config.get("attn_mode", "")).strip() or "torch"
+    if attn_mode == "torch" and torch_compile:
         errors.append(
             "attn_mode=torch cannot be combined with torch_compile=true in Anima Fast "
             "(#336); disable torch_compile or choose a supported attention mode"

--- a/mikazuki/anima_fast_backend/preflight.py
+++ b/mikazuki/anima_fast_backend/preflight.py
@@ -533,7 +533,7 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
     blocks_to_swap = _int_value(config.get("blocks_to_swap"), 0)
     cpu_offload = _truthy(config.get("cpu_offload_checkpointing"))
     unsloth = _truthy(config.get("unsloth_offload_checkpointing"))
-    torch_compile = _truthy(config.get("torch_compile", True))
+    torch_compile = _truthy(config.get("torch_compile", False))
 
     if blocks_to_swap > 0 and cpu_offload:
         errors.append("blocks_to_swap is incompatible with cpu_offload_checkpointing")
@@ -545,6 +545,11 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
     facts["resolution_tokens"] = tokens
     if torch_compile and not _truthy(config.get("compile_dynamic_seq", True)):
         errors.append("torch_compile requires compile_dynamic_seq with Anima v1.17.1 free-fit buckets")
+    if str(config.get("attn_mode", "")).strip() == "torch" and torch_compile:
+        errors.append(
+            "attn_mode=torch cannot be combined with torch_compile=true in Anima Fast "
+            "(#336); disable torch_compile or choose a supported attention mode"
+        )
 
     optimizer_type = str(config.get("optimizer_type", "")).strip().lower()
     if optimizer_type == "automagic":

--- a/mikazuki/anima_fast_backend/preflight.py
+++ b/mikazuki/anima_fast_backend/preflight.py
@@ -545,7 +545,10 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
     facts["resolution_tokens"] = tokens
     if torch_compile and not _truthy(config.get("compile_dynamic_seq", True)):
         errors.append("torch_compile requires compile_dynamic_seq with Anima v1.17.1 free-fit buckets")
-    attn_mode = str(config.get("attn_mode", "")).strip() or "torch"
+    raw_attn_mode = config.get("attn_mode")
+    attn_mode = str(raw_attn_mode or "").strip()
+    if attn_mode.lower() in {"", "undefined", "null", "nan"}:
+        attn_mode = "torch"
     if attn_mode == "torch" and torch_compile:
         errors.append(
             "attn_mode=torch cannot be combined with torch_compile=true in Anima Fast "

--- a/mikazuki/schema/anima-lora-fast.ts
+++ b/mikazuki/schema/anima-lora-fast.ts
@@ -16,7 +16,7 @@ Schema.intersect([
         timestep_sampling: Schema.union(["sigma", "uniform", "sigmoid", "shift", "flux_shift"]).default("shift").description("时间步采样"),
         discrete_flow_shift: Schema.number().step(0.001).default(3.0).description("Rectified Flow 位移"),
         attn_mode: Schema.union(["", "torch", "xformers", "sageattn", "flash"]).default("").description("Attention 加速实现。留空使用 torch 保底，避免 flash-attn 缺失导致预检查失败；手动选择 flash 需要插件环境已安装 flash-attn 且显卡支持"),
-        torch_compile: Schema.boolean().default(true).description("启用 torch.compile"),
+        torch_compile: Schema.boolean().default(false).description("启用 torch.compile；attn_mode=torch 时不可用（#336）"),
         compile_dynamic_seq: Schema.boolean().default(true).description("按 free-fit bucket 动态编译序列长度；开启 torch.compile 时必须启用"),
     }).description("Anima Fast 参数"),
 

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -2159,12 +2159,17 @@ class PreflightLauncherTests(unittest.TestCase):
                     "qwen3": str(root / "qwen.safetensors"),
                     "train_data_dir": str(root / "data"),
                     "gradient_checkpointing": True,
-                    "torch_compile": False,
+                    "torch_compile": True,
                     "compile_dynamic_seq": True,
-                    "attn_mode": "torch",
+                    "attn_mode": "flash",
                 },
                 runtime,
-                lambda _runtime: ProbeFacts("3.13.11", torch_metadata_version="2.11.0+cu130", cuda_available=True),
+                lambda _runtime: ProbeFacts(
+                    "3.13.11",
+                    torch_metadata_version="2.11.0+cu130",
+                    cuda_available=True,
+                    flash_attn_importable=True,
+                ),
             )
 
         self.assertTrue(result.ok, result.errors)
@@ -2189,6 +2194,41 @@ class PreflightLauncherTests(unittest.TestCase):
                     "torch_compile": True,
                     "compile_dynamic_seq": True,
                     "attn_mode": "torch",
+                },
+                runtime,
+                lambda _runtime: ProbeFacts(
+                    "3.13.11",
+                    torch_metadata_version="2.11.0+cu130",
+                    cuda_available=True,
+                ),
+            )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any("#336" in error and "torch_compile" in error for error in result.errors),
+            result.errors,
+        )
+
+    def test_preflight_rejects_empty_attention_with_compile(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            (root / "data").mkdir()
+            (root / "data" / "1.png").write_bytes(b"png")
+            (root / "data" / "1.txt").write_text("test", encoding="utf-8")
+            save_anima_model(root / "dit.safetensors")
+            for name in ("vae.safetensors", "qwen.safetensors"):
+                (root / name).write_bytes(b"x")
+
+            result = run_preflight(
+                {
+                    "pretrained_model_name_or_path": str(root / "dit.safetensors"),
+                    "vae": str(root / "vae.safetensors"),
+                    "qwen3": str(root / "qwen.safetensors"),
+                    "train_data_dir": str(root / "data"),
+                    "torch_compile": True,
+                    "compile_dynamic_seq": True,
+                    "attn_mode": "",
                 },
                 runtime,
                 lambda _runtime: ProbeFacts(

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -432,10 +432,41 @@ class AdapterTests(unittest.TestCase):
             adapted = adapt_config({
                 "lora_type": "lora",
                 "attn_mode": "",
+                "torch_compile": False,
             }, runtime, "run-1")
 
         self.assertEqual(adapted.values["attn_mode"], "torch")
         self.assertTrue(any("attn_mode" in warning for warning in adapted.warnings))
+
+    def test_adapt_config_rejects_torch_attention_with_compile(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+
+            with self.assertRaisesRegex(AdapterError, r"attn_mode=torch.*torch_compile"):
+                adapt_config(
+                    {
+                        "attn_mode": "torch",
+                        "torch_compile": True,
+                        "compile_dynamic_seq": True,
+                    },
+                    runtime,
+                    "run-1",
+                )
+
+    def test_adapt_config_allows_torch_attention_without_compile(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            adapted = adapt_config(
+                {
+                    "attn_mode": "torch",
+                    "torch_compile": False,
+                },
+                runtime,
+                "run-1",
+            )
+
+        self.assertEqual(adapted.values["attn_mode"], "torch")
+        self.assertFalse(adapted.values["torch_compile"])
 
     def test_adapt_config_ignores_v117_removed_fields(self):
         with tempfile.TemporaryDirectory() as td:
@@ -444,6 +475,7 @@ class AdapterTests(unittest.TestCase):
                 "lora_type": "lora",
                 "resolution": "1536,1536",
                 "torch_compile": True,
+                "attn_mode": "flash",
                 "static_token_count": 4096,
                 "compile_mode": "full",
                 "dynamo_backend": "eager",
@@ -460,6 +492,7 @@ class AdapterTests(unittest.TestCase):
                 {
                     "torch_compile": True,
                     "compile_dynamic_seq": False,
+                    "attn_mode": "flash",
                     "cache_latents": True,
                     "cache_text_encoder_outputs": True,
                 },
@@ -2126,7 +2159,7 @@ class PreflightLauncherTests(unittest.TestCase):
                     "qwen3": str(root / "qwen.safetensors"),
                     "train_data_dir": str(root / "data"),
                     "gradient_checkpointing": True,
-                    "torch_compile": True,
+                    "torch_compile": False,
                     "compile_dynamic_seq": True,
                     "attn_mode": "torch",
                 },
@@ -2135,6 +2168,41 @@ class PreflightLauncherTests(unittest.TestCase):
             )
 
         self.assertTrue(result.ok, result.errors)
+
+    def test_preflight_rejects_torch_attention_with_compile(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            (root / "data").mkdir()
+            (root / "data" / "1.png").write_bytes(b"png")
+            (root / "data" / "1.txt").write_text("test", encoding="utf-8")
+            save_anima_model(root / "dit.safetensors")
+            for name in ("vae.safetensors", "qwen.safetensors"):
+                (root / name).write_bytes(b"x")
+
+            result = run_preflight(
+                {
+                    "pretrained_model_name_or_path": str(root / "dit.safetensors"),
+                    "vae": str(root / "vae.safetensors"),
+                    "qwen3": str(root / "qwen.safetensors"),
+                    "train_data_dir": str(root / "data"),
+                    "torch_compile": True,
+                    "compile_dynamic_seq": True,
+                    "attn_mode": "torch",
+                },
+                runtime,
+                lambda _runtime: ProbeFacts(
+                    "3.13.11",
+                    torch_metadata_version="2.11.0+cu130",
+                    cuda_available=True,
+                ),
+            )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any("#336" in error and "torch_compile" in error for error in result.errors),
+            result.errors,
+        )
 
     def test_adapt_config_ignores_removed_compile_mode(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -468,6 +468,28 @@ class AdapterTests(unittest.TestCase):
         self.assertEqual(adapted.values["attn_mode"], "torch")
         self.assertFalse(adapted.values["torch_compile"])
 
+    def test_adapt_config_defaults_torch_compile_to_false(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            adapted = adapt_config({"attn_mode": "flash"}, runtime, "run-1")
+
+        self.assertFalse(adapted.values["torch_compile"])
+
+    def test_adapt_config_ignores_empty_torch_compile_values(self):
+        for empty_value in (None, "", "null"):
+            with self.subTest(empty_value=empty_value), tempfile.TemporaryDirectory() as td:
+                runtime = make_runtime(Path(td))
+                adapted = adapt_config(
+                    {
+                        "attn_mode": "torch",
+                        "torch_compile": empty_value,
+                    },
+                    runtime,
+                    "run-1",
+                )
+
+                self.assertFalse(adapted.values["torch_compile"])
+
     def test_adapt_config_ignores_v117_removed_fields(self):
         with tempfile.TemporaryDirectory() as td:
             runtime = make_runtime(Path(td))
@@ -2229,6 +2251,41 @@ class PreflightLauncherTests(unittest.TestCase):
                     "torch_compile": True,
                     "compile_dynamic_seq": True,
                     "attn_mode": "",
+                },
+                runtime,
+                lambda _runtime: ProbeFacts(
+                    "3.13.11",
+                    torch_metadata_version="2.11.0+cu130",
+                    cuda_available=True,
+                ),
+            )
+
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any("#336" in error and "torch_compile" in error for error in result.errors),
+            result.errors,
+        )
+
+    def test_preflight_rejects_none_attention_with_compile(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            (root / "data").mkdir()
+            (root / "data" / "1.png").write_bytes(b"png")
+            (root / "data" / "1.txt").write_text("test", encoding="utf-8")
+            save_anima_model(root / "dit.safetensors")
+            for name in ("vae.safetensors", "qwen.safetensors"):
+                (root / name).write_bytes(b"x")
+
+            result = run_preflight(
+                {
+                    "pretrained_model_name_or_path": str(root / "dit.safetensors"),
+                    "vae": str(root / "vae.safetensors"),
+                    "qwen3": str(root / "qwen.safetensors"),
+                    "train_data_dir": str(root / "data"),
+                    "torch_compile": True,
+                    "compile_dynamic_seq": True,
+                    "attn_mode": None,
                 },
                 runtime,
                 lambda _runtime: ProbeFacts(


### PR DESCRIPTION
## Summary

- Guard the Anima Fast `attn_mode=torch` + `torch_compile=true` combination reported in #336.
- Disable and clear `torch_compile` when the Vue training form switches to `torch`.
- Reject the unsafe combination in adapter and preflight, including API/TOML submissions that bypass the UI.
- Make the safe default explicit: torch attention runs without compile unless compile was explicitly requested; the schema defaults compile to off.

## Validation

- `python -m pytest tests/test_anima_fast_backend.py -q` -> 90 passed, 32 subtests
- `npm test` -> 18 test files, 98 tests passed
- `npm run typecheck` -> passed
- `npm run build` -> passed
- `git diff --check` -> passed

## Notes

The guard applies to all Anima Fast variants, not only Anima 2.9B. `flash`, `xformers`, and `sageattn` are not blocked by this issue; flash availability remains covered by the existing preflight check.

Please review the frontend behavior and the backend/API guard, especially the default handling for omitted `torch_compile`.
