### PR TITLE
fix(anima-fast): default validation_split_num to 0

### DIFF
--- a/mikazuki/engines/anima_fast/adapter.py
+++ b/mikazuki/engines/anima_fast/adapter.py
@@ -508,7 +508,7 @@ def dump_fast_dataset_toml(values: dict[str, Any]) -> str:
     repeats = int_value(values.get("dataset_repeats") or values.get("num_repeats"), 1) or 1
     dataset_values = {
         "batch_size": batch_size,
-        "validation_split_num": int_value(values.get("validation_split_num"), 16),
+        "validation_split_num": int_value(values.get("validation_split_num"), 0),
         "validation_seed": int_value(values.get("validation_seed"), 42),
     }
     for key in ("validation_split",):

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -324,6 +324,27 @@ class AdapterTests(unittest.TestCase):
         self.assertIn("[[datasets.subsets]]", text)
         self.assertIn("num_repeats = 7", text)
 
+    def test_dump_fast_dataset_toml_defaults_to_no_validation_split(self):
+        text = dump_fast_dataset_toml(
+            {
+                "resized_image_dir": "D:/data/resized",
+                "lora_cache_dir": "D:/data/lora",
+            }
+        )
+
+        self.assertIn("validation_split_num = 0", text)
+
+    def test_dump_fast_dataset_toml_respects_explicit_validation_split_num(self):
+        text = dump_fast_dataset_toml(
+            {
+                "resized_image_dir": "D:/data/resized",
+                "lora_cache_dir": "D:/data/lora",
+                "validation_split_num": 8,
+            }
+        )
+
+        self.assertIn("validation_split_num = 8", text)
+
     def test_dataset_cache_slug_from_relative_path(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
> 验证功能目前在产品层面是半个死功能，本 PR 只是停止让它白吃数据：
> 1. GUI schema 从未暴露 validation_split_num 字段——用户无法从界面配置验证集大小；
> 2. GUI 也没有 val loss 展示——即便验证集真的跑了，曲线只进 tensorboard，界面上不可见；
> 3. 因此对生成模型画风训练而言，验证 split 既无可见收益又静默扣图（小数据集 + bucket 下 val dataloader 常为 0）。默认改为 0 后无功能损失；将来若真有验证需求，需要一并补 schema 字段 + 前端 val loss 展示，届时再单独立项。