### PR TITLE
fix(anima-fast): disable unsafe torch compile combination

### DIFF
--- a/frontend/src/components/DynamicSchemaForm.test.ts
+++ b/frontend/src/components/DynamicSchemaForm.test.ts
@@ -37,4 +37,39 @@ describe("DynamicSchemaForm", () => {
     await wrapper.get(".reset").trigger("click")
     expect(wrapper.emitted("reset-field")?.[0]).toEqual(["mode"])
   })
+
+  it("disables Anima Fast torch compile and clears it when torch attention is selected", async () => {
+    const animaSchema: AdaptedSchema = {
+      ...schema,
+      name: "anima-lora-fast",
+      sections: [{
+        ...schema.sections[0],
+        fields: [
+          { key: "attn_mode", type: "string", options: ["", "torch", "flash"], conditions: [] },
+          { key: "torch_compile", type: "boolean", conditions: [] },
+        ],
+      }],
+    }
+    const wrapper = mount(DynamicSchemaForm, {
+      props: {
+        schema: animaSchema,
+        modelValue: { attn_mode: "torch", torch_compile: true },
+        errors: {},
+        effectiveDefaults: { attn_mode: "", torch_compile: false },
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          SchemaField: {
+            props: ["field"],
+            template: "<button class='field' :data-key='field.key' :data-disabled='field.disabled' @click='$emit(\"update:modelValue\", field.key === \"attn_mode\" ? \"torch\" : false)' />",
+          },
+        },
+      },
+    })
+
+    expect(wrapper.get("[data-key='torch_compile']").attributes("data-disabled")).toBe("true")
+    await wrapper.get("[data-key='attn_mode']").trigger("click")
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([{ attn_mode: "torch", torch_compile: false }])
+  })
 })

--- a/frontend/src/components/DynamicSchemaForm.vue
+++ b/frontend/src/components/DynamicSchemaForm.vue
@@ -2,7 +2,7 @@
 import { computed } from "vue"
 import { useI18n } from "vue-i18n"
 import type { AdaptedSchema, FormField, FormModel } from "../schema/adapter"
-import { isFieldActive } from "../schema/adapter"
+import { isAnimaFastTorchCompileBlocked, isFieldActive } from "../schema/adapter"
 import SchemaField from "./SchemaField.vue"
 
 const props = defineProps<{ schema: AdaptedSchema; modelValue: FormModel; errors: Record<string, string>; effectiveDefaults: FormModel }>()
@@ -23,8 +23,17 @@ function visibleFields(fields: FormField[]) {
   return fields.filter((field) => !field.hidden && selectedFields.value.get(field.key) === field)
 }
 
+function effectiveField(field: FormField) {
+  return field.key === "torch_compile" && isAnimaFastTorchCompileBlocked(props.schema, props.modelValue)
+    ? { ...field, disabled: true }
+    : field
+}
+
 function update(key: string, value: FormModel[string]) {
-  emit("update:modelValue", { ...props.modelValue, [key]: value })
+  const next = { ...props.modelValue, [key]: value }
+  if (key === "attn_mode" && isAnimaFastTorchCompileBlocked(props.schema, next)) next.torch_compile = false
+  if (key === "torch_compile" && isAnimaFastTorchCompileBlocked(props.schema, next)) next.torch_compile = false
+  emit("update:modelValue", next)
 }
 </script>
 
@@ -37,7 +46,7 @@ function update(key: string, value: FormModel[string]) {
         <SchemaField
           v-for="field in visibleFields(section.fields)"
           :key="field.key"
-          :field="field"
+          :field="effectiveField(field)"
           :model-value="modelValue[field.key]"
           :default-value="effectiveDefaults[field.key]"
           :error="errors[field.key]"

--- a/frontend/src/i18n/messages/en-US.ts
+++ b/frontend/src/i18n/messages/en-US.ts
@@ -167,6 +167,7 @@ export default {
       prodigyLr: "Prodigy works best with unet_lr and text_encoder_lr set to 1",
       oftSdxl: "OFT is currently only available for SDXL",
       conflict: "Parameters {left} and {right} conflict; enable only one of them",
+      animaFastTorchCompile: "torch_compile cannot be enabled when attn_mode is torch or empty",
     },
     schemas: {
       "sd3-lora": { title: "Anima LoRA", area: "Anima DiT · Kohya-ss · LoRA" },

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -167,6 +167,7 @@ export default {
       prodigyLr: "Prodigy 建议将 unet_lr、text_encoder_lr 设置为 1",
       oftSdxl: "OFT 当前仅对 SDXL 可用",
       conflict: "参数 {left} 与 {right} 冲突，请只启用其中一个",
+      animaFastTorchCompile: "attn_mode=torch 或留空时不能启用 torch_compile",
     },
     schemas: {
       "sd3-lora": { title: "Anima LoRA", area: "Anima DiT · Kohya-ss · LoRA" },

--- a/frontend/src/pages/TrainingPage.test.ts
+++ b/frontend/src/pages/TrainingPage.test.ts
@@ -105,12 +105,12 @@ const DynamicSchemaFormStub = defineComponent({
   `,
 })
 
-function mountPage() {
+function mountPage(schemaName = "test-schema") {
   return mount(TrainingPage, {
     props: {
       title: "Training",
       area: "Area",
-      schemaName: "test-schema",
+      schemaName,
       fieldDefaults: { sample_cfg: 5, tags: ["module-tag"] },
     },
     global: {
@@ -191,6 +191,30 @@ describe("TrainingPage single-field reset", () => {
     await flushPromises()
     expect(wrapper.get(".preview-panel pre").text()).not.toContain("advanced_only =")
     expect(wrapper.get(".preview-panel pre").text()).toContain('mode = "basic"')
+    wrapper.unmount()
+  })
+
+  it("normalizes unsafe carry-over when autosave JSON is malformed", async () => {
+    const animaFastSchema: AdaptedSchema = {
+      ...schema,
+      name: "anima-lora-fast",
+      sections: [{
+        ...schema.sections[0],
+        fields: [
+          ...schema.sections[0].fields,
+          { key: "attn_mode", type: "string", defaultValue: "", conditions: [] },
+          { key: "torch_compile", type: "boolean", defaultValue: false, conditions: [] },
+        ],
+      }],
+    }
+    vi.mocked(loadTrainingSchema).mockResolvedValue(animaFastSchema)
+    sessionStorage.setItem("mikazuki-carry-over", JSON.stringify({ attn_mode: "torch", torch_compile: true }))
+    localStorage.setItem("configs-anima-lora-fast-autosave", "{malformed")
+
+    const wrapper = mountPage("anima-lora-fast")
+    await flushPromises()
+
+    expect(wrapper.get(".model").text()).toContain('"torch_compile":false')
     wrapper.unmount()
   })
 })

--- a/frontend/src/pages/TrainingPage.vue
+++ b/frontend/src/pages/TrainingPage.vue
@@ -9,7 +9,7 @@ import ModelAssetsTools from "../components/ModelAssetsTools.vue"
 import SectionToc from "../components/SectionToc.vue"
 import { schemasApi } from "../api/schemas"
 import { trainingApi, type TrainingPreset, type TrainingStart } from "../api/training"
-import { applyReadonlyDefaults, cloneFormModel, cloneFormValue, createDefaultModel, isFieldActive, serializeModel, validateModel, type AdaptedSchema, type FormField, type FormModel } from "../schema/adapter"
+import { applyReadonlyDefaults, cloneFormModel, cloneFormValue, createDefaultModel, isFieldActive, normalizeModelForSchema, serializeModel, validateModel, type AdaptedSchema, type FormField, type FormModel } from "../schema/adapter"
 import { loadTrainingSchema } from "../schema/loader"
 import { buildTrainingConfig, checkTrainingConfig, hydrateImportedConfig, pickCarryOverFields, sanitizePersistedDraft } from "../training/params"
 import { moduleForTrainType } from "../training/modules"
@@ -112,7 +112,7 @@ async function applyImportedConfig(config: FormModel, successMessage?: string) {
     return
   }
   const defaults = effectiveDefaults.value
-  model.value = { ...cloneFormModel(defaults), ...hydrateImportedConfig(result.config || config) }
+  model.value = normalizeModelForSchema(schema.value!, { ...cloneFormModel(defaults), ...hydrateImportedConfig(result.config || config) })
   applyReadonlyDefaults(schema.value!, model.value, defaults)
   if (result.notice) ElMessage.info(result.notice)
   ElMessage.success(successMessage ?? t("training.importMsg.imported"))
@@ -141,7 +141,8 @@ async function load() {
       model.value = saved && typeof saved === "object"
         ? { ...base, ...sanitizePersistedDraft(saved as FormModel, defaults) }
         : base
-    } catch { model.value = base }
+      model.value = normalizeModelForSchema(loaded, model.value)
+    } catch { model.value = normalizeModelForSchema(loaded, base) }
     applyReadonlyDefaults(loaded, model.value, defaults)
     const cards = await schemasApi.graphicCards()
     if (cards.length > 1) {
@@ -198,7 +199,7 @@ async function openPresets() {
 }
 
 function applyPreset(preset: TrainingPreset) {
-  model.value = { ...model.value, ...preset.data }
+  model.value = normalizeModelForSchema(schema.value!, { ...model.value, ...preset.data })
   presetsOpen.value = false
   ElMessage.success(t("training.presetsDialog.applied", { name: preset.metadata.name }))
 }
@@ -268,7 +269,7 @@ async function resetConfig() {
     await ElMessageBox.confirm(t("training.actions.resetConfirm"), t("training.resetDialog.title"), { confirmButtonText: t("training.actions.reset"), cancelButtonText: t("training.resetDialog.cancel"), type: "warning" })
   } catch { return }
   localStorage.removeItem(autosaveKey())
-  model.value = cloneFormModel(effectiveDefaults.value)
+  model.value = normalizeModelForSchema(schema.value, effectiveDefaults.value)
   applyReadonlyDefaults(schema.value, model.value, effectiveDefaults.value)
   ElMessage.success(t("training.actions.resetDone"))
 }
@@ -277,14 +278,14 @@ function resetField(key: string) {
   if (!schema.value) return
   const next = { ...model.value, [key]: cloneFormValue(effectiveDefaults.value[key]) }
   applyReadonlyDefaults(schema.value, next, effectiveDefaults.value)
-  model.value = next
+  model.value = normalizeModelForSchema(schema.value, next)
   errors.value = validateModel(schema.value, model.value)
 }
 
 function applyHistory(row: FormModel) {
   if (!schema.value) return
   const defaults = effectiveDefaults.value
-  model.value = { ...cloneFormModel(defaults), ...sanitizePersistedDraft(row, defaults) }
+  model.value = normalizeModelForSchema(schema.value, { ...cloneFormModel(defaults), ...sanitizePersistedDraft(row, defaults) })
   applyReadonlyDefaults(schema.value, model.value, defaults)
   historyOpen.value = false
 }

--- a/frontend/src/schema/adapter.test.ts
+++ b/frontend/src/schema/adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { readdirSync, readFileSync } from "node:fs"
 import { resolve } from "node:path"
-import { applyReadonlyDefaults, createDefaultModel, executeSchemaSources, serializeModel } from "./adapter"
+import { applyReadonlyDefaults, createDefaultModel, executeSchemaSources, normalizeModelForSchema, serializeModel, validateModel } from "./adapter"
 
 const sources = [
   {
@@ -229,5 +229,24 @@ describe("dynamic schema adapter", () => {
       methods_subdir: "gui-methods",
       network_module: "networks.lora_anima",
     })
+  })
+
+  it("blocks the Anima Fast torch attention and torch compile combination", () => {
+    const schema = executeSchemaSources(
+      [{
+        name: "anima-lora-fast",
+        hash: "anima-lora-fast",
+        schema: `Schema.object({
+          attn_mode: Schema.union(["", "torch", "flash"]).default(""),
+          torch_compile: Schema.boolean().default(false),
+        })`,
+      }],
+      "anima-lora-fast",
+    )
+    const model = { attn_mode: "torch", torch_compile: true }
+
+    expect(serializeModel(schema, model)).toMatchObject({ attn_mode: "torch", torch_compile: false })
+    expect(Object.values(validateModel(schema, model)).join(" ")).toContain("attn_mode=torch")
+    expect(normalizeModelForSchema(schema, model)).toMatchObject({ attn_mode: "torch", torch_compile: false })
   })
 })

--- a/frontend/src/schema/adapter.ts
+++ b/frontend/src/schema/adapter.ts
@@ -197,6 +197,18 @@ export function isFieldActive(field: FormField, model: FormModel) {
   return field.conditions.every((condition) => model[condition.key] === condition.value)
 }
 
+export function isAnimaFastTorchCompileBlocked(schema: AdaptedSchema, model: FormModel) {
+  if (schema.name !== "anima-lora-fast") return false
+  const attnMode = String(model.attn_mode ?? "").trim().toLowerCase()
+  return attnMode === "" || attnMode === "torch"
+}
+
+export function normalizeModelForSchema(schema: AdaptedSchema, model: FormModel) {
+  const normalized = cloneFormModel(model)
+  if (isAnimaFastTorchCompileBlocked(schema, normalized)) normalized.torch_compile = false
+  return normalized
+}
+
 export function createDefaultModel(schema: AdaptedSchema): FormModel {
   const model: FormModel = {}
   for (const field of schema.sections.flatMap((section) => section.fields)) {
@@ -224,6 +236,10 @@ export function serializeModel(schema: AdaptedSchema, model: FormModel) {
   const output: FormModel = {}
   for (const field of schema.sections.flatMap((section) => section.fields)) {
     if (!isFieldActive(field, model)) continue
+    if (field.key === "torch_compile" && isAnimaFastTorchCompileBlocked(schema, model)) {
+      output[field.key] = false
+      continue
+    }
     const value = field.type === "const" ? field.constValue : model[field.key]
     if (value === undefined || value === "" || (Array.isArray(value) && !value.length)) continue
     output[field.key] = cloneFormValue(value)
@@ -243,6 +259,9 @@ export function validateModel(schema: AdaptedSchema, model: FormModel) {
     } else if (typeof value === "number" && field.max !== undefined && value > field.max) {
       errors[field.key] = i18n.global.t("schema.tooLarge", { max: field.max })
     }
+  }
+  if (isAnimaFastTorchCompileBlocked(schema, model) && model.torch_compile === true) {
+    errors.torch_compile = i18n.global.t("training.diagnostics.animaFastTorchCompile")
   }
   return errors
 }

--- a/mikazuki/engines/anima_fast/adapter.py
+++ b/mikazuki/engines/anima_fast/adapter.py
@@ -424,7 +424,10 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
 
     normalize_bucket_resolution(values, warnings)
 
-    values.setdefault("torch_compile", True)
+    if is_empty(values.get("torch_compile")):
+        values["torch_compile"] = False
+    else:
+        values.setdefault("torch_compile", False)
     values.setdefault("compile_dynamic_seq", True)
     if truthy(values.get("torch_compile")) and not truthy(values.get("compile_dynamic_seq")):
         values["compile_dynamic_seq"] = True
@@ -445,6 +448,11 @@ def adapt_config(source: dict[str, Any], runtime: RuntimeConfig, run_id: str) ->
     if is_empty(values.get("attn_mode")):
         values["attn_mode"] = "torch"
         warnings.append("attn_mode 留空时使用 torch 保底；如需 flash 请先确认插件环境已安装 flash-attn")
+    if values["attn_mode"] == "torch" and truthy(values.get("torch_compile")):
+        raise AdapterError(
+            "attn_mode=torch 与 torch_compile=true 组合存在兼容性风险；"
+            "请改用 flash/xformers，或关闭 torch_compile"
+        )
     values["method"] = "lora"
     values["methods_subdir"] = "gui-methods"
     values["network_module"] = "networks.lora_anima"

--- a/mikazuki/engines/anima_fast/preflight.py
+++ b/mikazuki/engines/anima_fast/preflight.py
@@ -377,7 +377,10 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
     blocks_to_swap = _int_value(config.get("blocks_to_swap"), 0)
     cpu_offload = _truthy(config.get("cpu_offload_checkpointing"))
     unsloth = _truthy(config.get("unsloth_offload_checkpointing"))
-    torch_compile = _truthy(config.get("torch_compile", True))
+    torch_compile = _truthy(config.get("torch_compile", False))
+    attn_mode = str(config.get("attn_mode", "") or "").strip().lower()
+    if not attn_mode:
+        attn_mode = "torch"
 
     if blocks_to_swap > 0 and cpu_offload:
         errors.append("blocks_to_swap is incompatible with cpu_offload_checkpointing")
@@ -385,6 +388,11 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
         errors.append("unsloth_offload_checkpointing is incompatible with cpu_offload_checkpointing")
     if unsloth and blocks_to_swap > 0:
         errors.append("unsloth_offload_checkpointing is incompatible with blocks_to_swap")
+    if attn_mode == "torch" and torch_compile:
+        errors.append(
+            "attn_mode=torch 与 torch_compile=true 组合存在兼容性风险；"
+            "请改用 flash/xformers，或关闭 torch_compile"
+        )
     tokens = _resolution_tokens(config)
     facts["resolution_tokens"] = tokens
     if torch_compile and not _truthy(config.get("compile_dynamic_seq", True)):
@@ -440,7 +448,7 @@ def run_preflight(config: dict[str, Any], runtime: RuntimeConfig, probe: Depende
                 "torch package metadata is missing (dist-info corrupt); "
                 "repair the Anima Fast plugin before training"
             )
-        if str(config.get("attn_mode", "")).strip() == "flash" and not dep.flash_attn_importable:
+        if attn_mode == "flash" and not dep.flash_attn_importable:
             errors.append(
                 "attn_mode=flash 需要 Fast 插件环境可导入 flash_attn；"
                 "请改用 torch/xformers，或先修复插件环境"

--- a/mikazuki/schema/anima-lora-fast.ts
+++ b/mikazuki/schema/anima-lora-fast.ts
@@ -16,7 +16,7 @@ Schema.intersect([
         timestep_sampling: Schema.union(["sigma", "uniform", "sigmoid", "shift", "flux_shift"]).default("shift").description("时间步采样"),
         discrete_flow_shift: Schema.number().step(0.001).default(3.0).description("Rectified Flow 位移"),
         attn_mode: Schema.union(["", "torch", "xformers", "sageattn", "flash"]).default("").description("Attention 加速实现。留空使用 torch 保底，避免 flash-attn 缺失导致预检查失败；手动选择 flash 需要插件环境已安装 flash-attn 且显卡支持"),
-        torch_compile: Schema.boolean().default(true).description("启用 torch.compile"),
+        torch_compile: Schema.boolean().default(false).description("启用 torch.compile；attn_mode=torch 或留空时禁止组合"),
         compile_dynamic_seq: Schema.boolean().default(true).description("按 free-fit bucket 动态编译序列长度；开启 torch.compile 时必须启用"),
     }).description("Anima Fast 参数"),
 

--- a/tests/test_anima_fast_backend.py
+++ b/tests/test_anima_fast_backend.py
@@ -352,6 +352,34 @@ class AdapterTests(unittest.TestCase):
         self.assertEqual(adapted.values["attn_mode"], "torch")
         self.assertTrue(any("attn_mode" in warning for warning in adapted.warnings))
 
+    def test_adapt_config_defaults_torch_compile_to_false(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            adapted = adapt_config({"lora_type": "lora"}, runtime, "run-1")
+
+        self.assertFalse(adapted.values["torch_compile"])
+
+    def test_adapt_config_rejects_torch_attention_with_torch_compile(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            with self.assertRaisesRegex(AdapterError, "attn_mode=torch.*torch_compile=true"):
+                adapt_config({
+                    "lora_type": "lora",
+                    "attn_mode": "torch",
+                    "torch_compile": True,
+                }, runtime, "run-1")
+
+    def test_adapt_config_treats_empty_compile_values_as_disabled(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = make_runtime(Path(td))
+            for empty_value in (None, "", "null"):
+                adapted = adapt_config({
+                    "lora_type": "lora",
+                    "attn_mode": "torch",
+                    "torch_compile": empty_value,
+                }, runtime, "run-1")
+                self.assertFalse(adapted.values["torch_compile"], empty_value)
+
     def test_adapt_config_ignores_removed_static_token_count(self):
         with tempfile.TemporaryDirectory() as td:
             runtime = make_runtime(Path(td))
@@ -359,6 +387,7 @@ class AdapterTests(unittest.TestCase):
                 "lora_type": "lora",
                 "resolution": "1536,1536",
                 "torch_compile": True,
+                "attn_mode": "flash",
                 "static_token_count": 4096,
             }, runtime, "run-1")
 
@@ -629,6 +658,30 @@ class PreflightLauncherTests(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertTrue(any("compile_dynamic_seq" in error for error in result.errors))
 
+    def test_preflight_rejects_torch_attention_with_torch_compile(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = make_runtime(root)
+            for file in ("model.safetensors", "vae.safetensors", "qwen.safetensors"):
+                (root / file).write_text("", encoding="utf-8")
+            dataset = root / "dataset"
+            dataset.mkdir()
+            (dataset / "a.png").write_text("", encoding="utf-8")
+            (dataset / "a.txt").write_text("caption", encoding="utf-8")
+
+            result = run_preflight({
+                "pretrained_model_name_or_path": "model.safetensors",
+                "vae": "vae.safetensors",
+                "qwen3": "qwen.safetensors",
+                "train_data_dir": "dataset",
+                "resolution": "64,64",
+                "attn_mode": "torch",
+                "torch_compile": True,
+            }, runtime, lambda _runtime: ProbeFacts("3.13.11", torch_metadata_version="2.11.0+cu130", cuda_available=True))
+
+        self.assertFalse(result.ok)
+        self.assertTrue(any("attn_mode=torch" in error and "torch_compile=true" in error for error in result.errors))
+
     def test_preflight_rejects_cache_flags_without_preprocess_cache(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -798,10 +851,15 @@ class PreflightLauncherTests(unittest.TestCase):
                     "gradient_checkpointing": True,
                     "torch_compile": True,
                     "compile_dynamic_seq": True,
-                    "attn_mode": "torch",
+                    "attn_mode": "flash",
                 },
                 runtime,
-                lambda _runtime: ProbeFacts("3.13.11", torch_metadata_version="2.11.0+cu130", cuda_available=True),
+                lambda _runtime: ProbeFacts(
+                    "3.13.11",
+                    torch_metadata_version="2.11.0+cu130",
+                    cuda_available=True,
+                    flash_attn_importable=True,
+                ),
             )
 
         self.assertTrue(result.ok, result.errors)


### PR DESCRIPTION
## Summary
- disable `torch_compile` by default for Anima Fast
- reject the unsafe `attn_mode=torch` or empty attention mode plus `torch_compile=true` combination in adapter and preflight
- disable and auto-clear the combination in the frontend, with serialization and validation guardrails
- add backend and frontend regression coverage

## Validation
- `python -m pytest tests/test_anima_fast_backend.py tests/test_anima_fast_environment_installer.py tests/test_anima_fast_integration_static.py tests/test_anima_fast_plugin_api.py tests/test_anima_fast_preprocess.py tests/test_install_anima_fast_cli.py -q`
- `npm test -- --run`
- `npm run typecheck`
- `npm run build`
- `npm run lint -- --quiet` (0 errors; 2 pre-existing warnings in `EngineStatusBar.vue`)

## Integration
This is the Anima Fast transition step for `dev`. `main` is intentionally unchanged.
